### PR TITLE
Surface notes and links in subtree and outline reads

### DIFF
--- a/internal/server/handler/find.go
+++ b/internal/server/handler/find.go
@@ -14,12 +14,21 @@ import (
 
 // subtreeNode is the JSON shape for xmind_get_subtree (not a raw xmind.Topic).
 type subtreeNode struct {
-	ID            string         `json:"id"`
-	Title         string         `json:"title,omitempty"`
-	Labels        []string       `json:"labels,omitempty"`
-	Markers       []xmind.Marker `json:"markers,omitempty"`
-	Children      []*subtreeNode `json:"children,omitempty"`
-	ChildrenCount int            `json:"childrenCount,omitempty"`
+	ID             string         `json:"id"`
+	Title          string         `json:"title,omitempty"`
+	StructureClass string         `json:"structureClass,omitempty"`
+	Labels         []string       `json:"labels,omitempty"`
+	Markers        []xmind.Marker `json:"markers,omitempty"`
+	Notes          string         `json:"notes,omitempty"`
+	Href           string         `json:"href,omitempty"`
+	Children       []*subtreeNode `json:"children,omitempty"`
+	ChildrenCount  int            `json:"childrenCount,omitempty"`
+}
+
+// subtreeOpts controls optional fields when building a subtree.
+type subtreeOpts struct {
+	includeNotes bool
+	includeLinks bool
 }
 
 func directChildCount(t *xmind.Topic) int {
@@ -29,41 +38,57 @@ func directChildCount(t *xmind.Topic) int {
 	return len(t.Children.Attached) + len(t.Children.Detached) + len(t.Children.Summary)
 }
 
-func topicToSubtree(t *xmind.Topic, curDepth int, maxDepth *int) *subtreeNode {
+func plainNoteContent(t *xmind.Topic) string {
+	if t == nil || t.Notes == nil || t.Notes.Plain == nil {
+		return ""
+	}
+	return t.Notes.Plain.Content
+}
+
+func topicToSubtree(t *xmind.Topic, curDepth int, maxDepth *int, opts subtreeOpts) *subtreeNode {
 	if t == nil {
 		return nil
 	}
 	n := &subtreeNode{
-		ID:      t.ID,
-		Title:   t.Title,
-		Labels:  append([]string(nil), t.Labels...),
-		Markers: append([]xmind.Marker(nil), t.Markers...),
+		ID:             t.ID,
+		Title:          t.Title,
+		StructureClass: t.StructureClass,
+		Labels:         append([]string(nil), t.Labels...),
+		Markers:        append([]xmind.Marker(nil), t.Markers...),
+	}
+	if opts.includeNotes {
+		if plain := plainNoteContent(t); plain != "" {
+			n.Notes = plain
+		}
+	}
+	if opts.includeLinks && t.Href != "" {
+		n.Href = t.Href
 	}
 	if maxDepth == nil {
-		n.Children = childSubtrees(t, curDepth, nil)
+		n.Children = childSubtrees(t, curDepth, nil, opts)
 		return n
 	}
 	if curDepth >= *maxDepth {
 		n.ChildrenCount = directChildCount(t)
 		return n
 	}
-	n.Children = childSubtrees(t, curDepth, maxDepth)
+	n.Children = childSubtrees(t, curDepth, maxDepth, opts)
 	return n
 }
 
-func childSubtrees(t *xmind.Topic, curDepth int, maxDepth *int) []*subtreeNode {
+func childSubtrees(t *xmind.Topic, curDepth int, maxDepth *int, opts subtreeOpts) []*subtreeNode {
 	if t == nil || t.Children == nil {
 		return nil
 	}
 	var out []*subtreeNode
 	for i := range t.Children.Attached {
-		out = append(out, topicToSubtree(&t.Children.Attached[i], curDepth+1, maxDepth))
+		out = append(out, topicToSubtree(&t.Children.Attached[i], curDepth+1, maxDepth, opts))
 	}
 	for i := range t.Children.Detached {
-		out = append(out, topicToSubtree(&t.Children.Detached[i], curDepth+1, maxDepth))
+		out = append(out, topicToSubtree(&t.Children.Detached[i], curDepth+1, maxDepth, opts))
 	}
 	for i := range t.Children.Summary {
-		out = append(out, topicToSubtree(&t.Children.Summary[i], curDepth+1, maxDepth))
+		out = append(out, topicToSubtree(&t.Children.Summary[i], curDepth+1, maxDepth, opts))
 	}
 	return out
 }
@@ -96,6 +121,18 @@ func parseDepthOptional(raw any) (*int, *mcp.CallToolResult) {
 	default:
 		return nil, mcp.NewToolResultError("invalid argument depth: expected a number")
 	}
+}
+
+// parseBoolOptional reads an optional boolean MCP argument; missing or null is false.
+func parseBoolOptional(args map[string]any, key string) (bool, *mcp.CallToolResult) {
+	if raw, has := args[key]; has && raw != nil {
+		v, ok := raw.(bool)
+		if !ok {
+			return false, mcp.NewToolResultError("invalid argument " + key + ": expected a boolean")
+		}
+		return v, nil
+	}
+	return false, nil
 }
 
 // GetSubtree returns a JSON subtree from the sheet root or a topic id.
@@ -156,7 +193,17 @@ func (h *XMindHandler) GetSubtree(ctx context.Context, req mcp.CallToolRequest) 
 		maxDepth = md
 	}
 
-	node := topicToSubtree(root, 0, maxDepth)
+	includeNotes, berr := parseBoolOptional(args, "include_notes")
+	if berr != nil {
+		return berr, nil
+	}
+	includeLinks, berr2 := parseBoolOptional(args, "include_links")
+	if berr2 != nil {
+		return berr2, nil
+	}
+	opts := subtreeOpts{includeNotes: includeNotes, includeLinks: includeLinks}
+
+	node := topicToSubtree(root, 0, maxDepth, opts)
 	out, err := json.Marshal(node)
 	if err != nil {
 		return nil, fmt.Errorf("marshal get_subtree response: %w", err)

--- a/internal/server/handler/find_test.go
+++ b/internal/server/handler/find_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mab-go/xmind-mcp/internal/xmind"
@@ -9,6 +10,49 @@ import (
 
 // Stable topic ID from kitchen-sink Sheet 1 (Mind Map): "Alpha" under Subtopic 1.
 const kitchenSinkAlphaTopicID = "169d72af-6345-47ad-90b0-5b587f1f9619"
+
+const kitchenSinkSheet10Title = "Sheet 10 - Topic Properties"
+
+// Topic IDs from internal/xmind/reader_test.go (Sheet 10 — Topic Properties).
+const (
+	kitchenSinkSheet10NoteTopicID = "83785e34-fcdb-4049-8c42-15052c20d8d6"
+	kitchenSinkSheet10HrefTopicID = "e0d8096f-cc1a-4c33-bcc5-db9006481f85"
+)
+
+func kitchenSinkSheetIDByTitle(t *testing.T, title string) string {
+	t.Helper()
+	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
+	if err != nil {
+		t.Fatalf("ReadMap: %v", err)
+	}
+	for i := range sheets {
+		if sheets[i].Title == title {
+			return sheets[i].ID
+		}
+	}
+	t.Fatalf("sheet not found: %s", title)
+	return ""
+}
+
+func assertSubtreeNoNotesField(t *testing.T, n *subtreeNode) {
+	t.Helper()
+	if n.Notes != "" {
+		t.Fatalf("expected no notes on node id %q, got %q", n.ID, n.Notes)
+	}
+	for _, c := range n.Children {
+		assertSubtreeNoNotesField(t, c)
+	}
+}
+
+func assertSubtreeNoHrefField(t *testing.T, n *subtreeNode) {
+	t.Helper()
+	if n.Href != "" {
+		t.Fatalf("expected no href on node id %q, got %q", n.ID, n.Href)
+	}
+	for _, c := range n.Children {
+		assertSubtreeNoHrefField(t, c)
+	}
+}
 
 func firstKitchenSinkSheetID(t *testing.T) string {
 	t.Helper()
@@ -383,5 +427,165 @@ func TestGetSubtreeDepthZero(t *testing.T) {
 	}
 	if node.ChildrenCount < 1 {
 		t.Fatalf("expected childrenCount, got %d", node.ChildrenCount)
+	}
+}
+
+func TestGetSubtreeSheet10StructureClassNotesHref(t *testing.T) {
+	h := NewXMindHandler()
+	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet10Title)
+
+	res := callTool(t, h.GetSubtree, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sid,
+	})
+	if res.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, res))
+	}
+	var root subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, res)), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if root.Title != "Central Topic" {
+		t.Fatalf("title: %q", root.Title)
+	}
+	if root.StructureClass != "org.xmind.ui.map.clockwise" {
+		t.Fatalf("structureClass: got %q", root.StructureClass)
+	}
+
+	resNotes := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sid,
+		"topic_id":      kitchenSinkSheet10NoteTopicID,
+		"include_notes": true,
+	})
+	if resNotes.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, resNotes))
+	}
+	var noteNode subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, resNotes)), &noteNode); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.HasPrefix(noteNode.Notes, "This is a simple, plain text note") {
+		t.Fatalf("notes: %q", noteNode.Notes)
+	}
+
+	resNoNotes := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sid,
+		"topic_id":      kitchenSinkSheet10NoteTopicID,
+		"include_notes": false,
+	})
+	if resNoNotes.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, resNoNotes))
+	}
+	var noNotesTree subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, resNoNotes)), &noNotesTree); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	assertSubtreeNoNotesField(t, &noNotesTree)
+
+	resNoHref := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sid,
+		"topic_id":      kitchenSinkSheet10HrefTopicID,
+		"include_links": false,
+	})
+	if resNoHref.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, resNoHref))
+	}
+	var noHrefTree subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, resNoHref)), &noHrefTree); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	assertSubtreeNoHrefField(t, &noHrefTree)
+
+	resHref := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sid,
+		"topic_id":      kitchenSinkSheet10HrefTopicID,
+		"include_links": true,
+	})
+	if resHref.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, resHref))
+	}
+	var hrefNode subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, resHref)), &hrefNode); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if hrefNode.Href != "https://www.google.com" {
+		t.Fatalf("href: %q", hrefNode.Href)
+	}
+}
+
+func TestGetSubtreeInvalidIncludeNotesType(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sheetID,
+		"include_notes": "yes",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for non-boolean include_notes")
+	}
+}
+
+func TestGetSubtreeInvalidIncludeLinksType(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sheetID,
+		"include_links": "yes",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for non-boolean include_links")
+	}
+}
+
+func TestGetSubtreeIncludeNotesAndLinksBothTrue(t *testing.T) {
+	h := NewXMindHandler()
+	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet10Title)
+	res := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sid,
+		"topic_id":      kitchenSinkSheet10NoteTopicID,
+		"include_notes": true,
+		"include_links": true,
+	})
+	if res.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, res))
+	}
+	var node subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, res)), &node); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.HasPrefix(node.Notes, "This is a simple, plain text note") {
+		t.Fatalf("notes: %q", node.Notes)
+	}
+}
+
+func TestGetSubtreeDepthWithIncludeFlags(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.GetSubtree, map[string]any{
+		"path":          kitchenSinkPath(t),
+		"sheet_id":      sheetID,
+		"depth":         float64(1),
+		"include_notes": true,
+		"include_links": true,
+	})
+	if res.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, res))
+	}
+	var node subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, res)), &node); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if node.Title != "Central Topic" {
+		t.Fatalf("root title: %q", node.Title)
+	}
+	if len(node.Children) < 1 {
+		t.Fatal("expected children at depth 1")
 	}
 }

--- a/internal/server/handler/utils.go
+++ b/internal/server/handler/utils.go
@@ -66,21 +66,39 @@ func (h *XMindHandler) FlattenToOutline(ctx context.Context, req mcp.CallToolReq
 		start = &sh.RootTopic
 	}
 
+	includeNotes, berr := parseBoolOptional(args, "include_notes")
+	if berr != nil {
+		return berr, nil
+	}
+
 	var b strings.Builder
-	flattenTopicWrite(&b, start, 0, format)
+	flattenTopicWrite(&b, start, 0, format, includeNotes)
 	return textResult(strings.TrimRight(b.String(), "\n")), nil
 }
 
-func flattenTopicWrite(b *strings.Builder, t *xmind.Topic, depth int, format string) {
+func flattenTopicWrite(b *strings.Builder, t *xmind.Topic, depth int, format string, includeNotes bool) {
 	title := ""
+	plain := ""
 	if t != nil {
 		title = t.Title
+		plain = plainNoteContent(t)
 	}
+	hasNotes := includeNotes && plain != ""
+
 	switch format {
 	case "text":
 		b.WriteString(strings.Repeat(" ", depth*2))
 		b.WriteString(title)
 		b.WriteByte('\n')
+		if hasNotes {
+			noteIndent := strings.Repeat(" ", depth*2+4)
+			for _, line := range strings.Split(plain, "\n") {
+				b.WriteString(noteIndent)
+				b.WriteString("[note] ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+		}
 	case "markdown":
 		// Use heading lines at every depth so import heading-mode parses the full tree (list lines would be ignored).
 		level := depth + 1
@@ -91,7 +109,14 @@ func flattenTopicWrite(b *strings.Builder, t *xmind.Topic, depth int, format str
 		b.WriteString(" ")
 		b.WriteString(title)
 		b.WriteByte('\n')
-		if depth == 0 {
+		if hasNotes {
+			for _, line := range strings.Split(plain, "\n") {
+				b.WriteString("> ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+			b.WriteByte('\n')
+		} else if depth == 0 {
 			b.WriteByte('\n')
 		}
 	}
@@ -99,7 +124,7 @@ func flattenTopicWrite(b *strings.Builder, t *xmind.Topic, depth int, format str
 		return
 	}
 	for i := range t.Children.Attached {
-		flattenTopicWrite(b, &t.Children.Attached[i], depth+1, format)
+		flattenTopicWrite(b, &t.Children.Attached[i], depth+1, format, includeNotes)
 	}
 }
 

--- a/internal/server/handler/utils_test.go
+++ b/internal/server/handler/utils_test.go
@@ -119,6 +119,68 @@ func TestFlattenToOutlineInvalidFormat(t *testing.T) {
 	}
 }
 
+func TestFlattenToOutlineIncludeNotesMarkdown(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes-md.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": rid, "notes": "Line1\nLine2",
+	})
+	res := callTool(t, h.FlattenToOutline, map[string]any{
+		"path": path, "sheet_id": sid, "format": "markdown", "include_notes": true,
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	out := textContent(t, res)
+	want := "# R\n> Line1\n> Line2"
+	if out != want {
+		t.Fatalf("got %q want %q", out, want)
+	}
+}
+
+func TestFlattenToOutlineIncludeNotesText(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes-txt.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": rid, "notes": "Line1\nLine2",
+	})
+	res := callTool(t, h.FlattenToOutline, map[string]any{
+		"path": path, "sheet_id": sid, "format": "text", "include_notes": true,
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	out := textContent(t, res)
+	want := "R\n    [note] Line1\n    [note] Line2"
+	if out != want {
+		t.Fatalf("got %q want %q", out, want)
+	}
+}
+
+func TestFlattenToOutlineInvalidIncludeNotesType(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad-notes.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	res := callTool(t, h.FlattenToOutline, map[string]any{
+		"path": path, "sheet_id": sheets[0].ID, "include_notes": "yes",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for non-boolean include_notes")
+	}
+}
+
 func TestImportFromOutlineHeadingMode(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -43,13 +43,16 @@ var toolDeleteSheet = mcp.NewTool(
 var toolGetSubtree = mcp.NewTool(
 	"xmind_get_subtree",
 	mcp.WithDescription(
-		"Return the topic hierarchy from a topic (or the sheet root). Optional depth limits nesting; "+
-			"truncated branches report childrenCount.",
+		"Return the topic hierarchy from a topic (or the sheet root). Each node includes id, title, labels, markers, "+
+			"and structureClass when the topic overrides sheet layout. Optional include_notes adds plain-text notes; "+
+			"include_links adds hyperlink href. Optional depth limits nesting; truncated branches report childrenCount.",
 	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet to read from")),
 	mcp.WithString("topic_id", mcp.Description("Root of the subtree; omit for sheet root")),
 	mcp.WithNumber("depth", mcp.Description("Max depth from subtree root (0 = root only with counts); omit for full tree; must be a whole number")),
+	mcp.WithBoolean("include_notes", mcp.Description("If true, include plain-text notes (notes.plain content) on nodes that have note text; omitted when empty")),
+	mcp.WithBoolean("include_links", mcp.Description("If true, include hyperlink href on nodes that have a link; omitted when empty")),
 )
 
 var toolSearchTopics = mcp.NewTool(
@@ -181,11 +184,16 @@ var toolAddBoundary = mcp.NewTool(
 
 var toolFlattenToOutline = mcp.NewTool(
 	"xmind_flatten_to_outline",
-	mcp.WithDescription("Export a topic subtree as indented plain text or Markdown (attached children only)."),
+	mcp.WithDescription(
+		"Export a topic subtree as indented plain text or Markdown (attached children only). "+
+			"Optional include_notes appends plain-text note lines below each topic: Markdown uses blockquotes (>), "+
+			"plain text uses indented [note] lines.",
+	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet to read from")),
 	mcp.WithString("topic_id", mcp.Description("Root of subtree; omit for sheet root")),
 	mcp.WithString("format", mcp.Description(`Output format: "text" or "markdown" (default "markdown")`)),
+	mcp.WithBoolean("include_notes", mcp.Description("If true, append each topic's plain note lines below its title line")),
 )
 
 var toolImportFromOutline = mcp.NewTool(


### PR DESCRIPTION
Callers can verify notes and links after writes without opening the raw zip. This commit adds optional flags on read tools and keeps defaults unchanged so existing integrations see the same payload size unless they opt in.

Features:
- `xmind_get_subtree`: optional `include_notes` / `include_links`; `subtreeNode` gains `structureClass`, `notes`, and `href` (plain text and href only; omitted when empty)
- `xmind_flatten_to_outline`: optional `include_notes` with Markdown blockquotes or text `[note]` lines under each title
- `parseBoolOptional` for MCP boolean args; `plainNoteContent` for `notes.plain` only

Tests:
- Kitchen sink Sheet 10 (by title) for structureClass, notes, href, invalid bools, combined flags, and depth with flags
- Outline note formatting and invalid `include_notes` type

Closes #1