### PR TITLE
Add list and delete relationship MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
 </p>
 
-An [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
-server for reading and writing local [XMind](https://xmind.com) mind map
-files. XMind MCP exposes 22 tools that let any MCP-compatible AI client
-create, navigate, and edit `.xmind` files directly on disk.
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server for
+reading and writing local [XMind](https://xmind.com) mind map files. XMind MCP
+exposes 24 tools that let any MCP-compatible AI client create, navigate, and
+edit `.xmind` files directly on disk.
 
 <p align="center">
   <img src="docs/xmind-mcp-repo-mind-map.png" alt="A mind map overview of the xmind-mcp project" width="85%" />
@@ -20,8 +20,13 @@ create, navigate, and edit `.xmind` files directly on disk.
 
 ## Prerequisites
 
+### Building
+
 - Go 1.26.1 or later
-- An MCP-compatible client (Claude Desktop, Cursor, etc.)
+
+### Using
+
+- Any MCP-compatible client (Claude Desktop, Cursor, etc.)
 
 ------------------------------------------------------------------------
 
@@ -97,11 +102,13 @@ environments.
 | `xmind_create_map`   | Create a new `.xmind` file with a single sheet and root topic.                                 |
 | `xmind_add_sheet`    | Add a new sheet to an existing workbook.                                                       |
 | `xmind_delete_sheet` | Remove a sheet from a workbook.                                                                |
+| `xmind_list_relationships` | List all relationships on a sheet (endpoint ids and topic titles as JSON).               |
 
 ### Tier 2: Finding Topics
 
-These are the entry point for any write operation. Always call one of
-these before mutating a specific topic.
+Use these to resolve topic ids and titles before editing a specific branch
+of the tree. Some write tools instead need sheet-level ids or ids from
+`xmind_list_relationships`—see each tool’s description.
 
 | Tool                  | Description                                                                       |
 |-----------------------|-----------------------------------------------------------------------------------|
@@ -111,7 +118,9 @@ these before mutating a specific topic.
 
 ### Tier 3: Topic Mutations
 
-All write tools require a `topic_id` obtained from a Tier 2 call.
+Most tools here target a topic and take a `topic_id` from Tier 2 (or from
+prior results). A few use other ids (`from_id`/`to_id`, `relationship_id`,
+etc.)—see each row.
 
 | Tool                         | Description                                                                   |
 |------------------------------|-------------------------------------------------------------------------------|
@@ -124,6 +133,7 @@ All write tools require a `topic_id` obtained from a Tier 2 call.
 | `xmind_set_topic_properties` | Set or update metadata on a topic: notes, labels, markers, and links.         |
 | `xmind_add_floating_topic`   | Add a detached floating topic not connected to the main hierarchy.            |
 | `xmind_add_relationship`     | Draw a labeled connector between any two topics.                              |
+| `xmind_delete_relationship`  | Remove a relationship by id (from `xmind_list_relationships`).                |
 | `xmind_add_summary`          | Add a summary callout bracketing a range of sibling topics.                   |
 | `xmind_add_boundary`         | Add a visual boundary enclosure around all children of a topic.               |
 
@@ -157,10 +167,10 @@ make run
 ```
 
 The primary test fixture is located at `testdata/kitchen-sink.xmind`. It
-exercises every supported XMind feature and should be used as the
-baseline for any handler development and testing. That file is stored in
-**Git LFS**; use a clone with LFS enabled (or run `git lfs pull`) before
-`make test`, or tests will fail on a pointer stub.
+exercises every supported XMind feature and should be used as the baseline for
+any handler development and testing. That file is stored in **Git LFS**; use a
+clone with LFS enabled (or run `git lfs pull`) before `make test`, or tests will
+fail on a pointer stub.
 
 ------------------------------------------------------------------------
 

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -884,6 +884,47 @@ func (h *XMindHandler) AddRelationship(ctx context.Context, req mcp.CallToolRequ
 	return textResult(fmt.Sprintf("added relationship id %s", relID)), nil
 }
 
+// DeleteRelationship removes a sheet-level relationship by id.
+func (h *XMindHandler) DeleteRelationship(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	args := req.GetArguments()
+	absPath, toolErr := absPathFromArgs(args)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	sheetID, terr := requireString(args, "sheet_id")
+	if terr != nil {
+		return terr, nil
+	}
+	relationshipID, terr := requireString(args, "relationship_id")
+	if terr != nil {
+		return terr, nil
+	}
+
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if toolErr2 != nil {
+		return toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+
+	idx := slices.IndexFunc(sh.Relationships, func(r xmind.Relationship) bool { return r.ID == relationshipID })
+	if idx < 0 {
+		return mcp.NewToolResultError(fmt.Sprintf("relationship not found on sheet %s: %s", sheetID, relationshipID)), nil
+	}
+	sh.Relationships = slices.Delete(sh.Relationships, idx, idx+1)
+	sh.RevisionID = uuid.New().String()
+	if err := xmind.WriteMap(absPath, sheets); err != nil {
+		return nil, fmt.Errorf("write map: %w", err)
+	}
+	return textResult(fmt.Sprintf("deleted relationship id %s", relationshipID)), nil
+}
+
 // AddSummary adds a summary topic and range descriptor on a parent (double-write).
 func (h *XMindHandler) AddSummary(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -777,6 +778,81 @@ func TestAddRelationship(t *testing.T) {
 	rel := sh.Relationships[0]
 	if rel.End1ID != aID || rel.End2ID != bID || rel.Title != "relates" {
 		t.Fatalf("unexpected relationship: %+v", rel)
+	}
+}
+
+func TestDeleteRelationship(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "delrel.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
+	})), "added topic id ")
+	bID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "B",
+	})), "added topic id ")
+
+	res := callTool(t, h.AddRelationship, map[string]any{
+		"path": path, "sheet_id": sid, "from_id": aID, "to_id": bID,
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	sh := &sheets[0]
+	if len(sh.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %+v", sh.Relationships)
+	}
+	relID := sh.Relationships[0].ID
+
+	res = callTool(t, h.DeleteRelationship, map[string]any{
+		"path": path, "sheet_id": sid, "relationship_id": relID,
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	if got, want := textContent(t, res), fmt.Sprintf("deleted relationship id %s", relID); got != want {
+		t.Fatalf("success text: got %q want %q", got, want)
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if len(sheets[0].Relationships) != 0 {
+		t.Fatalf("expected 0 relationships after delete, got %+v", sheets[0].Relationships)
+	}
+}
+
+func TestDeleteRelationshipNotFound(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "delrel_nf.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	res := callTool(t, h.DeleteRelationship, map[string]any{
+		"path": path, "sheet_id": sid, "relationship_id": "00000000-0000-0000-0000-000000000001",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error when relationship_id missing on sheet")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "relationship not found on sheet") || !strings.Contains(msg, sid) {
+		t.Fatalf("unexpected error: %q", msg)
+	}
+}
+
+func TestDeleteRelationshipInvalidSheetID(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "delrel_bad_sheet.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	res := callTool(t, h.DeleteRelationship, map[string]any{
+		"path": path, "sheet_id": "00000000-0000-0000-0000-000000000000", "relationship_id": "00000000-0000-0000-0000-000000000001",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for unknown sheet_id")
 	}
 }
 

--- a/internal/server/handler/sheets.go
+++ b/internal/server/handler/sheets.go
@@ -123,6 +123,80 @@ func (h *XMindHandler) ListSheets(ctx context.Context, req mcp.CallToolRequest) 
 	return textResult(string(out)), nil
 }
 
+// listRelationshipsResponse is the JSON shape returned by xmind_list_relationships.
+type listRelationshipsResponse struct {
+	SheetID           string                  `json:"sheetId"`
+	RelationshipCount int                     `json:"relationshipCount"`
+	Relationships     []listRelationshipsItem `json:"relationships"`
+}
+
+type listRelationshipsItem struct {
+	ID        string `json:"id"`
+	End1ID    string `json:"end1Id"`
+	End1Title string `json:"end1Title"`
+	End2ID    string `json:"end2Id"`
+	End2Title string `json:"end2Title"`
+	Title     string `json:"title,omitempty"`
+}
+
+// ListRelationships returns all relationships on a sheet with endpoint topic titles.
+func (h *XMindHandler) ListRelationships(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	args := req.GetArguments()
+	absPath, toolErr := absPathFromArgs(args)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	sheetID, terr := requireString(args, "sheet_id")
+	if terr != nil {
+		return terr, nil
+	}
+
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if toolErr2 != nil {
+		return toolErr2, nil
+	}
+
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+
+	rels := make([]listRelationshipsItem, 0, len(sh.Relationships))
+	for i := range sh.Relationships {
+		rel := &sh.Relationships[i]
+		item := listRelationshipsItem{
+			ID:     rel.ID,
+			End1ID: rel.End1ID,
+			End2ID: rel.End2ID,
+		}
+		if t1 := findTopicByID(&sh.RootTopic, rel.End1ID); t1 != nil {
+			item.End1Title = t1.Title
+		}
+		if t2 := findTopicByID(&sh.RootTopic, rel.End2ID); t2 != nil {
+			item.End2Title = t2.Title
+		}
+		if rel.Title != "" {
+			item.Title = rel.Title
+		}
+		rels = append(rels, item)
+	}
+
+	resp := listRelationshipsResponse{
+		SheetID:           sh.ID,
+		RelationshipCount: len(rels),
+		Relationships:     rels,
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal list_relationships response: %w", err)
+	}
+	return textResult(string(out)), nil
+}
+
 // bumpAllSheetsRevisionID assigns a new UUID v4 revisionId to every sheet in the slice (in place).
 func bumpAllSheetsRevisionID(sheets []xmind.Sheet) {
 	for i := range sheets {

--- a/internal/server/handler/sheets_test.go
+++ b/internal/server/handler/sheets_test.go
@@ -253,3 +253,107 @@ func TestDeleteLastSheetError(t *testing.T) {
 		t.Fatal("expected tool error when deleting last sheet")
 	}
 }
+
+func TestListRelationshipsKitchenSink(t *testing.T) {
+	h := NewXMindHandler()
+	res := callTool(t, h.ListRelationships, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": kitchenSinkRelationshipsSheetID,
+	})
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textContent(t, res))
+	}
+	var out listRelationshipsResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.SheetID != kitchenSinkRelationshipsSheetID {
+		t.Fatalf("sheetId: got %q want %q", out.SheetID, kitchenSinkRelationshipsSheetID)
+	}
+	const wantRelCount = 2 // kitchen-sink Sheet 12 (kitchenSinkRelationshipsSheetID)
+	if out.RelationshipCount != wantRelCount || len(out.Relationships) != wantRelCount {
+		t.Fatalf("relationshipCount/relationships: got count=%d len=%d want %d", out.RelationshipCount, len(out.Relationships), wantRelCount)
+	}
+	if len(out.Relationships) != out.RelationshipCount {
+		t.Fatalf("relationships len %d vs relationshipCount %d", len(out.Relationships), out.RelationshipCount)
+	}
+	foundNonEmpty := false
+	for _, r := range out.Relationships {
+		if r.End1Title != "" && r.End2Title != "" {
+			foundNonEmpty = true
+			break
+		}
+	}
+	if !foundNonEmpty {
+		t.Fatal("expected at least one relationship with non-empty end1Title and end2Title")
+	}
+	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sh *xmind.Sheet
+	for i := range sheets {
+		if sheets[i].ID == kitchenSinkRelationshipsSheetID {
+			sh = &sheets[i]
+			break
+		}
+	}
+	if sh == nil {
+		t.Fatal("sheet not found in kitchen sink")
+	}
+	if len(sh.Relationships) != len(out.Relationships) {
+		t.Fatalf("ReadMap rel count %d vs list %d", len(sh.Relationships), len(out.Relationships))
+	}
+	id0 := sh.Relationships[0].ID
+	var got *listRelationshipsItem
+	for i := range out.Relationships {
+		if out.Relationships[i].ID == id0 {
+			got = &out.Relationships[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("list output missing relationship id %s", id0)
+	}
+	if got.End1ID != sh.Relationships[0].End1ID || got.End2ID != sh.Relationships[0].End2ID {
+		t.Fatalf("endpoint ids: got %+v want End1=%q End2=%q", got, sh.Relationships[0].End1ID, sh.Relationships[0].End2ID)
+	}
+}
+
+func TestListRelationshipsEmptySheet(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "emptyrel.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid := sheets[0].ID
+	res := callTool(t, h.ListRelationships, map[string]any{"path": path, "sheet_id": sid})
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textContent(t, res))
+	}
+	var out listRelationshipsResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.RelationshipCount != 0 || len(out.Relationships) != 0 {
+		t.Fatalf("want empty relationships, got count=%d len=%d", out.RelationshipCount, len(out.Relationships))
+	}
+	raw := textContent(t, res)
+	if !strings.Contains(raw, `"relationships":[]`) {
+		t.Fatalf("expected explicit empty relationships array in JSON: %s", raw)
+	}
+}
+
+func TestListRelationshipsInvalidSheetID(t *testing.T) {
+	h := NewXMindHandler()
+	res := callTool(t, h.ListRelationships, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": "00000000-0000-0000-0000-000000000000",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for unknown sheet_id")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,8 @@ func newXMindServer(ctx context.Context, h *handler.XMindHandler) *mcpserver.MCP
 	s.AddTool(toolSetTopicProperties, h.SetTopicProperties)
 	s.AddTool(toolAddFloatingTopic, h.AddFloatingTopic)
 	s.AddTool(toolAddRelationship, h.AddRelationship)
+	s.AddTool(toolListRelationships, h.ListRelationships)
+	s.AddTool(toolDeleteRelationship, h.DeleteRelationship)
 	s.AddTool(toolAddSummary, h.AddSummary)
 	s.AddTool(toolAddBoundary, h.AddBoundary)
 	s.AddTool(toolFlattenToOutline, h.FlattenToOutline)

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -162,6 +162,26 @@ var toolAddRelationship = mcp.NewTool(
 	mcp.WithString("label", mcp.Description("Optional label on the connector")),
 )
 
+var toolListRelationships = mcp.NewTool(
+	"xmind_list_relationships",
+	mcp.WithDescription(
+		"List all sheet-level relationships as JSON: sheetId, relationshipCount, and relationships (endpoint ids, "+
+			"titles, optional connector title).",
+	),
+	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
+	mcp.WithString("sheet_id", mcp.Required(), mcp.Description(
+		"Sheet to read. Each item's end1Id/end2Id correspond to from_id/to_id on xmind_add_relationship; optional title matches the add tool's label.",
+	)),
+)
+
+var toolDeleteRelationship = mcp.NewTool(
+	"xmind_delete_relationship",
+	mcp.WithDescription("Remove a sheet-level relationship by id (from xmind_list_relationships)."),
+	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
+	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet containing the relationship")),
+	mcp.WithString("relationship_id", mcp.Required(), mcp.Description("ID of the relationship to delete")),
+)
+
 var toolAddSummary = mcp.NewTool(
 	"xmind_add_summary",
 	mcp.WithDescription("Add a summary callout spanning a range of sibling attached children (double-write to children.summary and summaries)."),


### PR DESCRIPTION
This commit adds sheet-level relationship listing as JSON and deletion by ID, alongside registration and tool definitions. README now lists 24 tools, documents the new Tier 1 and Tier 3 rows, and softens Tier 2/3 intros so mixed ID sources are accurate. Prerequisites are split into Building vs Using.

Features:
- `ListRelationships` in `sheets.go` (endpoint IDs, titles, optional connector title)
- `DeleteRelationship` in `mutate.go` with revision bump and `relationship not found on sheet ...` tool errors

Tests:
- Kitchen-sink golden count and ReadMap cross-check for first relationship
- Empty `relationships` array, invalid `sheet_id`, delete not-found and wrong-sheet cases