### PR TITLE
Add optional parent_id to xmind_find_topic

### DIFF
--- a/internal/server/handler/find.go
+++ b/internal/server/handler/find.go
@@ -367,6 +367,7 @@ func childTitlesInWalkOrder(t *xmind.Topic) []string {
 }
 
 // FindTopic returns the first topic with an exact case-sensitive title (preorder DFS).
+// If parent_id is set, the walk starts at that topic (which may itself match).
 func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
 	args := req.GetArguments()
@@ -409,9 +410,25 @@ func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (
 		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
 
+	searchRoot := &sh.RootTopic
+	if v, has := args["parent_id"]; has && v != nil {
+		pid, ok := v.(string)
+		if !ok {
+			return mcp.NewToolResultError("invalid argument parent_id: expected a string"), nil
+		}
+		if pid == "" {
+			return mcp.NewToolResultError("invalid argument parent_id: expected a non-empty string"), nil
+		}
+		topic := findTopicByID(&sh.RootTopic, pid)
+		if topic == nil {
+			return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", pid)), nil
+		}
+		searchRoot = topic
+	}
+
 	var found *xmind.Topic
 	var foundParent *xmind.Topic
-	walkTopics(&sh.RootTopic, 0, nil, func(t *xmind.Topic, _ int, parent *xmind.Topic) bool {
+	walkTopics(searchRoot, 0, nil, func(t *xmind.Topic, _ int, parent *xmind.Topic) bool {
 		if t.Title == wantTitle {
 			found = t
 			foundParent = parent

--- a/internal/server/handler/find_test.go
+++ b/internal/server/handler/find_test.go
@@ -11,6 +11,9 @@ import (
 // Stable topic ID from kitchen-sink Sheet 1 (Mind Map): "Alpha" under Subtopic 1.
 const kitchenSinkAlphaTopicID = "169d72af-6345-47ad-90b0-5b587f1f9619"
 
+// Parent of "Alpha" on Sheet 1 - Mind Map.
+const kitchenSinkSubtopic1TopicID = "61cc4754-20ec-4479-9e58-f7eaa985520a"
+
 const kitchenSinkSheet10Title = "Sheet 10 - Topic Properties"
 
 // Topic IDs from internal/xmind/reader_test.go (Sheet 10 — Topic Properties).
@@ -126,8 +129,8 @@ func TestFindTopicKitchenSink(t *testing.T) {
 	if out.Title != "Alpha" {
 		t.Fatalf("title: got %q", out.Title)
 	}
-	if out.ID == "" {
-		t.Fatal("empty id")
+	if out.ID != kitchenSinkAlphaTopicID {
+		t.Fatalf("id: got %q want %q", out.ID, kitchenSinkAlphaTopicID)
 	}
 }
 
@@ -404,6 +407,126 @@ func TestFindTopicEmptyTitle(t *testing.T) {
 	})
 	if !res.IsError {
 		t.Fatal("expected tool error for empty title")
+	}
+}
+
+func TestFindTopicParentIDWrongType(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Alpha",
+		"parent_id": 123,
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for non-string parent_id")
+	}
+	if !strings.Contains(textContent(t, res), "expected a string") {
+		t.Fatalf("error text: %s", textContent(t, res))
+	}
+}
+
+func TestFindTopicParentIDEmptyString(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Alpha",
+		"parent_id": "",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for empty parent_id")
+	}
+	if !strings.Contains(textContent(t, res), "non-empty string") {
+		t.Fatalf("error text: %s", textContent(t, res))
+	}
+}
+
+func TestFindTopicParentIDUnknown(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Alpha",
+		"parent_id": "00000000-0000-0000-0000-000000000000",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for unknown parent_id")
+	}
+	if !strings.Contains(textContent(t, res), "topic not found") {
+		t.Fatalf("error text: %s", textContent(t, res))
+	}
+}
+
+// "Central Topic" exists only as the sheet root; it is not under Subtopic 1's subtree.
+func TestFindTopicScopedTitleNotUnderParent(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Central Topic",
+		"parent_id": kitchenSinkSubtopic1TopicID,
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error when title exists on sheet but not under parent_id scope")
+	}
+	if !strings.Contains(textContent(t, res), "no topic with title") {
+		t.Fatalf("error text: %s", textContent(t, res))
+	}
+}
+
+func TestFindTopicScopedDescendant(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Alpha",
+		"parent_id": kitchenSinkSubtopic1TopicID,
+	})
+	if res.IsError {
+		t.Fatalf("FindTopic: %s", textContent(t, res))
+	}
+	var out findTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ID != kitchenSinkAlphaTopicID {
+		t.Fatalf("id: got %q want %q", out.ID, kitchenSinkAlphaTopicID)
+	}
+	if out.ParentTitle != "Subtopic 1" {
+		t.Fatalf("parentTitle: got %q want Subtopic 1", out.ParentTitle)
+	}
+}
+
+func TestFindTopicParentIDSelfMatch(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Alpha",
+		"parent_id": kitchenSinkAlphaTopicID,
+	})
+	if res.IsError {
+		t.Fatalf("FindTopic: %s", textContent(t, res))
+	}
+	var out findTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ID != kitchenSinkAlphaTopicID {
+		t.Fatalf("id: got %q want %q", out.ID, kitchenSinkAlphaTopicID)
+	}
+	if out.ParentTitle != "" {
+		t.Fatalf("parentTitle: got %q want empty (scope root matched)", out.ParentTitle)
+	}
+	if len(out.SiblingTitles) != 0 {
+		t.Fatalf("expected no siblingTitles when scope root matches, got %#v", out.SiblingTitles)
 	}
 }
 

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -69,12 +69,20 @@ var toolSearchTopics = mcp.NewTool(
 var toolFindTopic = mcp.NewTool(
 	"xmind_find_topic",
 	mcp.WithDescription(
-		"Find a topic by exact title (case-sensitive). Returns the first depth-first match; "+
-			"use xmind_search_topics if the title may be ambiguous.",
+		"Find a topic by exact title (case-sensitive). Returns the first depth-first match within the chosen scope. "+
+			"Optional parent_id is the subtree root to search under (same role as topic_id on xmind_get_subtree); "+
+			"it is not the structural parent used by xmind_add_topic and other write tools. "+
+			"Omit parent_id or null for the whole sheet. The scope root is visited first, so it can match if its title equals the search title; "+
+			"parentTitle and siblingTitles are relative to that walk, so they are empty when the match is the scope root. "+
+			"Use xmind_search_topics for substring or cross-sheet search.",
 	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
-	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet to search")),
+	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("title", mcp.Required(), mcp.Description("Exact topic title to find (non-empty)")),
+	mcp.WithString("parent_id", mcp.Description(
+		"Topic ID for the subtree root to search (omit or null for the entire sheet). "+
+			"Unlike parent_id on add/import tools, this does not designate a parent for new topics.",
+	)),
 )
 
 var toolAddTopic = mcp.NewTool(


### PR DESCRIPTION
This commit scopes exact-title lookup to a subtree when parent_id is set, so duplicate titles can be distinguished by branch. Omit or null preserves whole-sheet search.

- Register optional parent_id on toolFindTopic with MCP docs that disambiguate parent_id from write tools and note walk-relative parentTitle/siblingTitles; align sheet_id description with other tools
- Resolve searchRoot via findTopicByID in FindTopic; walk from searchRoot; split invalid parent_id errors for wrong type vs empty string
- Add kitchen-sink tests for validation, scoped descendant match, scope-root self-match, title present on sheet but not under scope, and tightened baseline Alpha match

Closes #3