### PR TITLE
Extend set_topic_properties with clearable notes + remove_markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ etc.)—see each row.
 | `xmind_delete_topic`         | Remove a topic and all its descendants.                                       |
 | `xmind_move_topic`           | Reparent a topic (and its subtree) to a new parent.                           |
 | `xmind_reorder_children`     | Change the order of a topic's children without reparenting.                   |
-| `xmind_set_topic_properties` | Set or update metadata on a topic: notes, labels, markers, and links.         |
+| `xmind_set_topic_properties` | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool. |
 | `xmind_add_floating_topic`   | Add a detached floating topic not connected to the main hierarchy.            |
 | `xmind_add_relationship`     | Draw a labeled connector between any two topics.                              |
 | `xmind_delete_relationship`  | Remove a relationship by id (from `xmind_list_relationships`).                |

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -720,14 +720,22 @@ func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolR
 		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
 	}
 
-	if v, has := args["notes"]; has && v != nil {
-		s, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument notes: expected a string"), nil
-		}
-		topic.Notes = &xmind.Notes{
-			Plain:    &xmind.NoteContent{Content: s},
-			RealHTML: &xmind.NoteContent{Content: plainToRealHTML(s)},
+	if v, has := args["notes"]; has {
+		if v == nil {
+			topic.Notes = nil
+		} else {
+			s, ok := v.(string)
+			if !ok {
+				return mcp.NewToolResultError("invalid argument notes: expected a string"), nil
+			}
+			if s == "" {
+				topic.Notes = nil
+			} else {
+				topic.Notes = &xmind.Notes{
+					Plain:    &xmind.NoteContent{Content: s},
+					RealHTML: &xmind.NoteContent{Content: plainToRealHTML(s)},
+				}
+			}
 		}
 	}
 	if v, has := args["labels"]; has && v != nil {
@@ -759,6 +767,29 @@ func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolR
 			markers = append(markers, xmind.Marker{MarkerID: s})
 		}
 		topic.Markers = markers
+	}
+	if v, has := args["remove_markers"]; has && v != nil {
+		arr, ok := v.([]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid argument remove_markers: expected an array"), nil
+		}
+		if len(arr) > 0 {
+			remove := make(map[string]struct{}, len(arr))
+			for i, el := range arr {
+				s, ok := el.(string)
+				if !ok {
+					return mcp.NewToolResultError(fmt.Sprintf("remove_markers[%d]: expected string", i)), nil
+				}
+				remove[s] = struct{}{}
+			}
+			out := make([]xmind.Marker, 0, len(topic.Markers))
+			for _, m := range topic.Markers {
+				if _, drop := remove[m.MarkerID]; !drop {
+					out = append(out, m)
+				}
+			}
+			topic.Markers = out
+		}
 	}
 	if v, has := args["link"]; has && v != nil {
 		s, ok := v.(string)

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -512,7 +512,7 @@ func TestSetTopicProperties(t *testing.T) {
 		topic.Notes.RealHTML == nil || topic.Notes.RealHTML.Content != "<div>Note body</div>" {
 		t.Fatalf("notes: %+v", topic.Notes)
 	}
-	if len(topic.Labels) != 2 || topic.Labels[0] != "l1" {
+	if len(topic.Labels) != 2 || topic.Labels[0] != "l1" || topic.Labels[1] != "l2" {
 		t.Fatalf("labels: %v", topic.Labels)
 	}
 	if len(topic.Markers) != 1 || topic.Markers[0].MarkerID != "priority-1" {
@@ -719,6 +719,179 @@ func TestSetTopicPropertiesPartial(t *testing.T) {
 	}
 	if len(topic.Markers) != 1 || topic.Markers[0].MarkerID != "task-done" {
 		t.Fatalf("markers: %+v", topic.Markers)
+	}
+}
+
+func TestSetTopicPropertiesClearSemantics(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clearsem.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	tid := sheets[0].RootTopic.ID
+
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"notes": "keep", "labels": []any{"x"}, "markers": []any{"priority-1"}, "link": "https://a.example",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid, "notes": "",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if sheets[0].RootTopic.Notes != nil {
+		t.Fatalf("notes empty string: want nil, got %+v", sheets[0].RootTopic.Notes)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"notes": "n2", "labels": []any{"y"}, "markers": []any{"task-done"}, "link": "https://b.example",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid, "notes": nil,
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if sheets[0].RootTopic.Notes != nil {
+		t.Fatalf("notes nil: want nil, got %+v", sheets[0].RootTopic.Notes)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid, "labels": []any{},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if len(sheets[0].RootTopic.Labels) != 0 {
+		t.Fatalf("labels: want empty, got %v", sheets[0].RootTopic.Labels)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid, "markers": []any{},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if len(sheets[0].RootTopic.Markers) != 0 {
+		t.Fatalf("markers: want empty, got %+v", sheets[0].RootTopic.Markers)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid, "link": "",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if sheets[0].RootTopic.Href != "" {
+		t.Fatalf("link: want empty href, got %q", sheets[0].RootTopic.Href)
+	}
+}
+
+func TestSetTopicPropertiesRemoveMarkers(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rmmarkers.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	tid := sheets[0].RootTopic.ID
+
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"markers": []any{"priority-1", "task-done"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"remove_markers": []any{},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	m := sheets[0].RootTopic.Markers
+	if len(m) != 2 {
+		t.Fatalf("empty remove_markers: want two markers, got %+v", m)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"remove_markers": []any{"unknown-id"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	m = sheets[0].RootTopic.Markers
+	if len(m) != 2 {
+		t.Fatalf("unknown remove id: want two markers, got %+v", m)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"remove_markers": []any{"priority-1"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	m = sheets[0].RootTopic.Markers
+	if len(m) != 1 || m[0].MarkerID != "task-done" {
+		t.Fatalf("partial remove: want [task-done], got %+v", m)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"markers": []any{},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if len(sheets[0].RootTopic.Markers) != 0 {
+		t.Fatalf("markers empty array: want no markers, got %+v", sheets[0].RootTopic.Markers)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"remove_markers": []any{"still-unknown"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	if len(sheets[0].RootTopic.Markers) != 0 {
+		t.Fatalf("remove_markers with no markers: want empty, got %+v", sheets[0].RootTopic.Markers)
+	}
+
+	res = callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": tid,
+		"markers": []any{"a", "b"}, "remove_markers": []any{"a"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	m = sheets[0].RootTopic.Markers
+	if len(m) != 1 || m[0].MarkerID != "b" {
+		t.Fatalf("markers then remove: want [b], got %+v", m)
 	}
 }
 
@@ -1178,6 +1351,72 @@ func TestSetTopicPropertiesMissingTopicID(t *testing.T) {
 	})
 	if !res.IsError {
 		t.Fatal("expected error when topic_id is missing")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "topic_id") {
+		t.Fatalf("expected topic_id in error message, got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesNotesWrongType(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "noteswrong.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	tid := sheets[0].RootTopic.ID
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sheets[0].ID, "topic_id": tid,
+		"notes": float64(42),
+	})
+	if !res.IsError {
+		t.Fatal("expected error when notes is not a string")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "invalid argument notes") {
+		t.Fatalf("expected invalid argument notes in message, got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesMarkersWrongType(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mkwrong.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	tid := sheets[0].RootTopic.ID
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sheets[0].ID, "topic_id": tid,
+		"markers": "not-an-array",
+	})
+	if !res.IsError {
+		t.Fatal("expected error when markers is not an array")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "invalid argument markers") {
+		t.Fatalf("expected invalid argument markers in message, got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesMultilineNoteHTML(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mlnote.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	tid := sheets[0].RootTopic.ID
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sheets[0].ID, "topic_id": tid,
+		"notes": "a\nb",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	n := sheets[0].RootTopic.Notes
+	want := "<div>a</div><div>b</div>"
+	if n == nil || n.RealHTML == nil || n.RealHTML.Content != want {
+		t.Fatalf("multiline RealHTML: want %q, got %+v", want, n)
 	}
 }
 

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -142,14 +142,21 @@ var toolReorderChildren = mcp.NewTool(
 
 var toolSetTopicProperties = mcp.NewTool(
 	"xmind_set_topic_properties",
-	mcp.WithDescription("Set optional metadata on a topic: notes, labels, markers, link. Only provided fields are updated."),
+	mcp.WithDescription(
+		"Set optional metadata on a topic: notes, labels, markers, link, remove_markers. Only provided fields are updated. "+
+			"Clearing cheat sheet: notes use empty string or null to clear; link uses empty string to clear (omit the key or pass null to leave the link unchanged). "+
+			"labels or markers use an empty array to clear all. remove_markers is applied after markers when both are set; empty remove_markers removes nothing, "+
+			"unlike an empty markers array which clears all markers. "+
+			"Null semantics: only notes treats JSON null as clear; for labels, markers, remove_markers, and link, omit the key or pass null to leave that field unchanged.",
+	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("topic_id", mcp.Required(), mcp.Description("ID of the topic to update")),
-	mcp.WithString("notes", mcp.Description("Plain text note (plain + HTML fields set to the same string)")),
-	mcp.WithArray("labels", mcp.Description("List of label strings")),
-	mcp.WithArray("markers", mcp.Description(`Marker IDs, e.g. "priority-1", "task-done"`)),
-	mcp.WithString("link", mcp.Description("URL, file path, or topic link href")),
+	mcp.WithString("notes", mcp.Description("Plain text note (plain + HTML fields set); empty string or null clears notes (only this field uses null to clear)")),
+	mcp.WithArray("labels", mcp.Description("List of label strings; empty array clears all labels; omit or null leaves labels unchanged")),
+	mcp.WithArray("markers", mcp.Description(`Full marker ID list, e.g. "priority-1", "task-done"; empty array clears all markers; omit or null leaves markers unchanged`)),
+	mcp.WithArray("remove_markers", mcp.Description(`Marker IDs to remove after any markers replace; empty array removes nothing; omit or null leaves markers unchanged; applied after markers when both are set`)),
+	mcp.WithString("link", mcp.Description("URL, file path, or topic link href; empty string clears the link; omit or null leaves the link unchanged")),
 )
 
 var toolAddFloatingTopic = mcp.NewTool(


### PR DESCRIPTION
This commit fixes notes clearing (empty string and JSON null set notes to nil instead of writing an empty notes object) and adds remove_markers after the full markers replace. MCP tool descriptions document clearing and null semantics for LLM callers; README Tier 3 row mentions remove_markers. Tests cover clear semantics, marker removal edge cases, invalid argument types, multiline note HTML, and stricter assertions.

- SetTopicProperties: clear notes; filter remove_markers by marker ID
- tools: xmind_set_topic_properties description and parameter help
- README: update xmind_set_topic_properties row
- mutate_test: new and expanded SetTopicProperties tests

Closes #4