### PR TITLE
Improve 'move topic' position discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ etc.)—see each row.
 | `xmind_add_topics_bulk`      | Add multiple topics (flat list or nested subtree) under a parent in one call. |
 | `xmind_rename_topic`         | Change the title of an existing topic.                                        |
 | `xmind_delete_topic`         | Remove a topic and all its descendants.                                       |
-| `xmind_move_topic`           | Reparent a topic (and its subtree) to a new parent.                           |
+| `xmind_move_topic`           | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append). |
 | `xmind_reorder_children`     | Change the order of a topic's children without reparenting.                   |
 | `xmind_set_topic_properties` | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool. |
 | `xmind_add_floating_topic`   | Add a detached floating topic not connected to the main hierarchy.            |

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -604,7 +604,8 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
-	return textResult(fmt.Sprintf("moved topic %s under %s", topicID, newParentID)), nil
+	n := len(newParent.Children.Attached)
+	return textResult(fmt.Sprintf("moved topic %s to position %d under %s (%d attached children)", topicID, moveInsertIdx, newParentID, n)), nil
 }
 
 // ReorderChildren reorders attached children of parent_id.

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -123,12 +123,12 @@ var toolDeleteTopic = mcp.NewTool(
 
 var toolMoveTopic = mcp.NewTool(
 	"xmind_move_topic",
-	mcp.WithDescription("Move a topic (and subtree) to a new parent as an attached child."),
+	mcp.WithDescription("Move a topic (and subtree) to a new parent as an attached child. Use position to control insertion order; omit to append at the end."),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("topic_id", mcp.Required(), mcp.Description("ID of the topic to move")),
 	mcp.WithString("new_parent_id", mcp.Required(), mcp.Description("ID of the new parent topic")),
-	mcp.WithNumber("position", mcp.Description("Sibling index under new parent; omit to append")),
+	mcp.WithNumber("position", mcp.Description("Zero-based insertion index among the new parent's attached children (0 = first child); valid range is 0 to the current child count. Omit to append at end.")),
 )
 
 var toolReorderChildren = mcp.NewTool(


### PR DESCRIPTION
This commit makes the optional position argument easier to discover in MCP tool metadata and spells out zero-based index rules. The MoveTopic success message now includes the final insertion index and attached child count so callers can confirm placement without an extra reorder call.

- Expand `toolMoveTopic` and `position` descriptions in `internal/server/tools.go`
- Enrich `MoveTopic` text response in `internal/server/handler/mutate.go`
- Align the README tool table with MCP wording

Closes #5