### PR TITLE
Add xmind_get_topic_properties tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server for
 reading and writing local [XMind](https://xmind.com) mind map files. XMind MCP
-exposes 24 tools that let any MCP-compatible AI client create, navigate, and
+exposes 25 tools that let any MCP-compatible AI client create, navigate, and
 edit `.xmind` files directly on disk.
 
 <p align="center">
@@ -110,11 +110,12 @@ Use these to resolve topic ids and titles before editing a specific branch
 of the tree. Some write tools instead need sheet-level ids or ids from
 `xmind_list_relationships`—see each tool’s description.
 
-| Tool                  | Description                                                                       |
-|-----------------------|-----------------------------------------------------------------------------------|
-| `xmind_get_subtree`   | Return the full topic hierarchy rooted at a given topic (or the whole sheet).     |
-| `xmind_search_topics` | Search for topics by keyword; returns matching topics with their IDs and context. |
-| `xmind_find_topic`    | Find a single topic by exact title; returns its ID and immediate context.         |
+| Tool                         | Description                                                                       |
+|------------------------------|-----------------------------------------------------------------------------------|
+| `xmind_get_subtree`          | Return the full topic hierarchy rooted at a given topic (or the whole sheet).     |
+| `xmind_get_topic_properties` | Return one topic's metadata as JSON (notes, markers, boundaries, sheet relationships for that topic, child counts); use to verify writes. |
+| `xmind_search_topics`        | Search for topics by keyword; returns matching topics with their IDs and context. |
+| `xmind_find_topic`         | Find a single topic by exact title; returns its ID and immediate context.         |
 
 ### Tier 3: Topic Mutations
 

--- a/internal/server/handler/find.go
+++ b/internal/server/handler/find.go
@@ -457,3 +457,168 @@ func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (
 	}
 	return textResult(string(out)), nil
 }
+
+// topicPropertiesResponse is the JSON shape for xmind_get_topic_properties.
+type topicPropertiesResponse struct {
+	ID             string                        `json:"id"`
+	Title          string                        `json:"title,omitempty"`
+	StructureClass string                        `json:"structureClass,omitempty"`
+	Labels         []string                      `json:"labels,omitempty"`
+	Markers        []xmind.Marker                `json:"markers,omitempty"`
+	Notes          string                        `json:"notes,omitempty"`
+	Href           string                        `json:"href,omitempty"`
+	ImageSrc       string                        `json:"imageSrc,omitempty"`
+	Position       *topicPropertiesPosition      `json:"position,omitempty"`
+	BoundaryCount  int                           `json:"boundaryCount,omitempty"`
+	Boundaries     []topicPropertiesBoundary     `json:"boundaries,omitempty"`
+	SummaryCount   int                           `json:"summaryCount,omitempty"`
+	Relationships  []topicPropertiesRelationship `json:"relationships,omitempty"`
+	ChildCounts    *topicPropertiesChildCounts   `json:"childCounts,omitempty"`
+}
+
+type topicPropertiesPosition struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+type topicPropertiesBoundary struct {
+	ID    string `json:"id"`
+	Range string `json:"range"`
+	Title string `json:"title,omitempty"`
+}
+
+type topicPropertiesRelationship struct {
+	ID     string `json:"id"`
+	End1ID string `json:"end1Id"`
+	End2ID string `json:"end2Id"`
+	Title  string `json:"title,omitempty"`
+}
+
+type topicPropertiesChildCounts struct {
+	Attached int `json:"attached,omitempty"`
+	Detached int `json:"detached,omitempty"`
+	Summary  int `json:"summary,omitempty"`
+}
+
+func topicPropertiesResponseFrom(sh *xmind.Sheet, topic *xmind.Topic) topicPropertiesResponse {
+	if topic == nil {
+		return topicPropertiesResponse{}
+	}
+	out := topicPropertiesResponse{
+		ID:             topic.ID,
+		Title:          topic.Title,
+		StructureClass: topic.StructureClass,
+	}
+	if len(topic.Labels) > 0 {
+		out.Labels = append([]string(nil), topic.Labels...)
+	}
+	if len(topic.Markers) > 0 {
+		out.Markers = append([]xmind.Marker(nil), topic.Markers...)
+	}
+	if plain := plainNoteContent(topic); plain != "" {
+		out.Notes = plain
+	}
+	if topic.Href != "" {
+		out.Href = topic.Href
+	}
+	if topic.Image != nil && topic.Image.Src != "" {
+		out.ImageSrc = topic.Image.Src
+	}
+	if topic.Position != nil {
+		out.Position = &topicPropertiesPosition{X: topic.Position.X, Y: topic.Position.Y}
+	}
+	if n := len(topic.Boundaries); n > 0 {
+		out.BoundaryCount = n
+		out.Boundaries = make([]topicPropertiesBoundary, 0, n)
+		for i := range topic.Boundaries {
+			b := &topic.Boundaries[i]
+			out.Boundaries = append(out.Boundaries, topicPropertiesBoundary{
+				ID:    b.ID,
+				Range: b.Range,
+				Title: b.Title,
+			})
+		}
+	}
+	if sc := len(topic.Summaries); sc > 0 {
+		out.SummaryCount = sc
+	}
+	if sh != nil && len(sh.Relationships) > 0 {
+		for i := range sh.Relationships {
+			rel := &sh.Relationships[i]
+			if rel.End1ID != topic.ID && rel.End2ID != topic.ID {
+				continue
+			}
+			item := topicPropertiesRelationship{
+				ID:     rel.ID,
+				End1ID: rel.End1ID,
+				End2ID: rel.End2ID,
+			}
+			if rel.Title != "" {
+				item.Title = rel.Title
+			}
+			out.Relationships = append(out.Relationships, item)
+		}
+	}
+	if topic.Children != nil {
+		a := len(topic.Children.Attached)
+		d := len(topic.Children.Detached)
+		s := len(topic.Children.Summary)
+		if a > 0 || d > 0 || s > 0 {
+			cc := &topicPropertiesChildCounts{}
+			if a > 0 {
+				cc.Attached = a
+			}
+			if d > 0 {
+				cc.Detached = d
+			}
+			if s > 0 {
+				cc.Summary = s
+			}
+			out.ChildCounts = cc
+		}
+	}
+	return out
+}
+
+// GetTopicProperties returns JSON with a single topic's metadata for verification after writes.
+func (h *XMindHandler) GetTopicProperties(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	args := req.GetArguments()
+	absPath, toolErr := absPathFromArgs(args)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	sheetID, terr := requireString(args, "sheet_id")
+	if terr != nil {
+		return terr, nil
+	}
+	topicID, terr := requireString(args, "topic_id")
+	if terr != nil {
+		return terr, nil
+	}
+
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if toolErr2 != nil {
+		return toolErr2, nil
+	}
+
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+
+	t := findTopicByID(&sh.RootTopic, topicID)
+	if t == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
+	}
+
+	resp := topicPropertiesResponseFrom(sh, t)
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal get_topic_properties response: %w", err)
+	}
+	return textResult(string(out)), nil
+}

--- a/internal/server/handler/find_test.go
+++ b/internal/server/handler/find_test.go
@@ -712,3 +712,247 @@ func TestGetSubtreeDepthWithIncludeFlags(t *testing.T) {
 		t.Fatal("expected children at depth 1")
 	}
 }
+
+func TestGetTopicPropertiesSheet10NotesHrefStructureClass(t *testing.T) {
+	h := NewXMindHandler()
+	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet10Title)
+
+	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
+	if err != nil {
+		t.Fatalf("ReadMap: %v", err)
+	}
+	var rootID string
+	for i := range sheets {
+		if sheets[i].Title == kitchenSinkSheet10Title {
+			rootID = sheets[i].RootTopic.ID
+			break
+		}
+	}
+	if rootID == "" {
+		t.Fatal("sheet 10 not found")
+	}
+
+	resRoot := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sid,
+		"topic_id": rootID,
+	})
+	if resRoot.IsError {
+		t.Fatalf("GetTopicProperties: %s", textContent(t, resRoot))
+	}
+	var rootProps topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, resRoot)), &rootProps); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rootProps.StructureClass != "org.xmind.ui.map.clockwise" {
+		t.Fatalf("structureClass: got %q", rootProps.StructureClass)
+	}
+
+	resNotes := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sid,
+		"topic_id": kitchenSinkSheet10NoteTopicID,
+	})
+	if resNotes.IsError {
+		t.Fatalf("GetTopicProperties: %s", textContent(t, resNotes))
+	}
+	var noteProps topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, resNotes)), &noteProps); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.HasPrefix(noteProps.Notes, "This is a simple, plain text note") {
+		t.Fatalf("notes: %q", noteProps.Notes)
+	}
+
+	resHref := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sid,
+		"topic_id": kitchenSinkSheet10HrefTopicID,
+	})
+	if resHref.IsError {
+		t.Fatalf("GetTopicProperties: %s", textContent(t, resHref))
+	}
+	var hrefProps topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, resHref)), &hrefProps); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if hrefProps.Href != "https://www.google.com" {
+		t.Fatalf("href: %q", hrefProps.Href)
+	}
+}
+
+func TestGetTopicPropertiesRelationshipsFiltered(t *testing.T) {
+	h := NewXMindHandler()
+	path := kitchenSinkPath(t)
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatalf("ReadMap: %v", err)
+	}
+	var sh *xmind.Sheet
+	for i := range sheets {
+		if sheets[i].ID == kitchenSinkRelationshipsSheetID {
+			sh = &sheets[i]
+			break
+		}
+	}
+	if sh == nil {
+		t.Fatal("relationships sheet not found")
+	}
+	if len(sh.Relationships) == 0 {
+		t.Fatal("expected at least one relationship on kitchen-sink relationships sheet")
+	}
+	end1 := sh.Relationships[0].End1ID
+	var wantCount int
+	for i := range sh.Relationships {
+		r := &sh.Relationships[i]
+		if r.End1ID == end1 || r.End2ID == end1 {
+			wantCount++
+		}
+	}
+
+	res := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     path,
+		"sheet_id": kitchenSinkRelationshipsSheetID,
+		"topic_id": end1,
+	})
+	if res.IsError {
+		t.Fatalf("GetTopicProperties: %s", textContent(t, res))
+	}
+	var out topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Relationships) != wantCount {
+		t.Fatalf("relationships: got %d want %d", len(out.Relationships), wantCount)
+	}
+	byID := make(map[string]topicPropertiesRelationship, len(out.Relationships))
+	for _, r := range out.Relationships {
+		byID[r.ID] = r
+	}
+	for i := range sh.Relationships {
+		r := &sh.Relationships[i]
+		if r.End1ID != end1 && r.End2ID != end1 {
+			continue
+		}
+		got, ok := byID[r.ID]
+		if !ok {
+			t.Fatalf("missing relationship id %s in response", r.ID)
+		}
+		if got.End1ID != r.End1ID || got.End2ID != r.End2ID {
+			t.Fatalf("endpoint mismatch for %s: got %+v want End1=%q End2=%q", r.ID, got, r.End1ID, r.End2ID)
+		}
+	}
+}
+
+func TestGetTopicPropertiesKitchenSinkBoundarySummaryPosition(t *testing.T) {
+	path := kitchenSinkPath(t)
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatalf("ReadMap: %v", err)
+	}
+	var boundarySheetID, boundaryTopicID string
+	var summarySheetID, summaryTopicID string
+	var posSheetID, posTopicID string
+	for si := range sheets {
+		sh := &sheets[si]
+		walkTopics(&sh.RootTopic, 0, nil, func(topic *xmind.Topic, _ int, _ *xmind.Topic) bool {
+			if boundarySheetID == "" && len(topic.Boundaries) > 0 {
+				boundarySheetID = sh.ID
+				boundaryTopicID = topic.ID
+			}
+			if summarySheetID == "" && len(topic.Summaries) > 0 {
+				summarySheetID = sh.ID
+				summaryTopicID = topic.ID
+			}
+			if posSheetID == "" && topic.Position != nil {
+				posSheetID = sh.ID
+				posTopicID = topic.ID
+			}
+			return true
+		})
+	}
+	if boundarySheetID == "" || boundaryTopicID == "" {
+		t.Fatal("kitchen-sink fixture must include a topic with boundaries (see AGENTS.md test fixture)")
+	}
+	if summarySheetID == "" || summaryTopicID == "" {
+		t.Fatal("kitchen-sink fixture must include a topic with summaries (see AGENTS.md test fixture)")
+	}
+	if posSheetID == "" || posTopicID == "" {
+		t.Fatal("kitchen-sink fixture must include a topic with position (floating topic; see AGENTS.md test fixture)")
+	}
+
+	h := NewXMindHandler()
+
+	resB := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     path,
+		"sheet_id": boundarySheetID,
+		"topic_id": boundaryTopicID,
+	})
+	if resB.IsError {
+		t.Fatalf("GetTopicProperties (boundary): %s", textContent(t, resB))
+	}
+	var bOut topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, resB)), &bOut); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if bOut.BoundaryCount != len(bOut.Boundaries) || bOut.BoundaryCount < 1 {
+		t.Fatalf("boundaryCount/boundaries: %+v", bOut)
+	}
+
+	resS := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     path,
+		"sheet_id": summarySheetID,
+		"topic_id": summaryTopicID,
+	})
+	if resS.IsError {
+		t.Fatalf("GetTopicProperties (summary): %s", textContent(t, resS))
+	}
+	var sOut topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, resS)), &sOut); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if sOut.SummaryCount < 1 {
+		t.Fatalf("summaryCount: got %+v", sOut)
+	}
+
+	resP := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     path,
+		"sheet_id": posSheetID,
+		"topic_id": posTopicID,
+	})
+	if resP.IsError {
+		t.Fatalf("GetTopicProperties (position): %s", textContent(t, resP))
+	}
+	var pOut topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, resP)), &pOut); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pOut.Position == nil {
+		t.Fatal("expected position on floating topic")
+	}
+}
+
+func TestGetTopicPropertiesUnknownTopic(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sheetID,
+		"topic_id": "00000000-0000-0000-0000-000000000000",
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for unknown topic_id")
+	}
+}
+
+func TestGetTopicPropertiesMissingTopicID(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.GetTopicProperties, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sheetID,
+	})
+	if !res.IsError {
+		t.Fatal("expected tool error for missing topic_id")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ func newXMindServer(ctx context.Context, h *handler.XMindHandler) *mcpserver.MCP
 	s.AddTool(toolAddSheet, h.AddSheet)
 	s.AddTool(toolDeleteSheet, h.DeleteSheet)
 	s.AddTool(toolGetSubtree, h.GetSubtree)
+	s.AddTool(toolGetTopicProperties, h.GetTopicProperties)
 	s.AddTool(toolSearchTopics, h.SearchTopics)
 	s.AddTool(toolFindTopic, h.FindTopic)
 	s.AddTool(toolAddTopic, h.AddTopic)

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -55,6 +55,20 @@ var toolGetSubtree = mcp.NewTool(
 	mcp.WithBoolean("include_links", mcp.Description("If true, include hyperlink href on nodes that have a link; omitted when empty")),
 )
 
+var toolGetTopicProperties = mcp.NewTool(
+	"xmind_get_topic_properties",
+	mcp.WithDescription(
+		"Return JSON for a single topic: id, title, structureClass, labels, markers, plain-text notes, hyperlink href, "+
+			"image source, position (floating topics), boundaries (with range and title), summaryCount (range descriptors on this topic), "+
+			"relationships on the sheet that reference this topic (end1Id/end2Id; sheet-level storage), and childCounts as direct child counts "+
+			"by list (attached, detached, summary — not the same as summaryCount). Use xmind_get_subtree for the full hierarchy. "+
+			"Use after writes to verify what was stored.",
+	),
+	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
+	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet containing the topic")),
+	mcp.WithString("topic_id", mcp.Required(), mcp.Description("ID of the topic to inspect")),
+)
+
 var toolSearchTopics = mcp.NewTool(
 	"xmind_search_topics",
 	mcp.WithDescription(


### PR DESCRIPTION
This commit adds a read-only tool that returns one topic's metadata as JSON (notes, markers, boundaries, filtered sheet relationships, child counts, etc.) so callers can verify writes without using xmind_get_subtree for the whole tree.

- Register tool in tools.go and server.go
- Implement GetTopicProperties and response types in find.go
- Add kitchen-sink coverage in find_test.go
- Document the tool in README Tier 2

Closes #11