### PR TITLE
Add xmind_duplicate_topic MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ internal/
     hooks.go              — MCP lifecycle hooks (before/after initialize)
     handler/
       handler.go          — XMindHandler struct and shared utilities (textResult, etc.)
+      handler_test.go     — tests for handler helpers (e.g. deepCloneTopic)
       sheets.go           — handlers for Tier 1: file & sheet management tools
       find.go             — handlers for Tier 2: search/find tools
       mutate.go           — handlers for Tier 3: topic mutation tools
@@ -180,6 +181,7 @@ func textResult(text string) *mcp.CallToolResult {
 | `findParentOfTopic(root, targetID)` | Parent topic, child index, and list name (`"attached"`, `"detached"`, `"summary"`) |
 | `isDescendantOf(ancestor, descendantID)` | Reports whether a node is the ancestor or any node in its subtree |
 | `countTopics(t)` | Total node count for a subtree (self + all descendants) |
+| `deepCloneTopic(root)` | JSON round-trip clone of a subtree, then fresh UUIDs for topics and summary/boundary descriptors |
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server for
 reading and writing local [XMind](https://xmind.com) mind map files. XMind MCP
-exposes 25 tools that let any MCP-compatible AI client create, navigate, and
+exposes 26 tools that let any MCP-compatible AI client create, navigate, and
 edit `.xmind` files directly on disk.
 
 <p align="center">
@@ -95,14 +95,14 @@ environments.
 
 ### Tier 1: File & Sheet Management
 
-| Tool                 | Description                                                                                    |
-|----------------------|------------------------------------------------------------------------------------------------|
-| `xmind_open_map`     | Parse a `.xmind` file and return a structural summary (sheet names, root topics, node counts). |
-| `xmind_list_sheets`  | Return the names and IDs of all sheets in a workbook.                                          |
-| `xmind_create_map`   | Create a new `.xmind` file with a single sheet and root topic.                                 |
-| `xmind_add_sheet`    | Add a new sheet to an existing workbook.                                                       |
-| `xmind_delete_sheet` | Remove a sheet from a workbook.                                                                |
-| `xmind_list_relationships` | List all relationships on a sheet (endpoint ids and topic titles as JSON).               |
+| Tool                       | Description                                                                                    |
+|----------------------------|------------------------------------------------------------------------------------------------|
+| `xmind_open_map`           | Parse a `.xmind` file and return a structural summary (sheet names, root topics, node counts). |
+| `xmind_list_sheets`        | Return the names and IDs of all sheets in a workbook.                                          |
+| `xmind_create_map`         | Create a new `.xmind` file with a single sheet and root topic.                                 |
+| `xmind_add_sheet`          | Add a new sheet to an existing workbook.                                                       |
+| `xmind_delete_sheet`       | Remove a sheet from a workbook.                                                                |
+| `xmind_list_relationships` | List all relationships on a sheet (endpoint ids and topic titles as JSON).                     |
 
 ### Tier 2: Finding Topics
 
@@ -110,12 +110,12 @@ Use these to resolve topic ids and titles before editing a specific branch
 of the tree. Some write tools instead need sheet-level ids or ids from
 `xmind_list_relationships`—see each tool’s description.
 
-| Tool                         | Description                                                                       |
-|------------------------------|-----------------------------------------------------------------------------------|
-| `xmind_get_subtree`          | Return the full topic hierarchy rooted at a given topic (or the whole sheet).     |
+| Tool                         | Description                                                                                                                               |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `xmind_get_subtree`          | Return the full topic hierarchy rooted at a given topic (or the whole sheet).                                                             |
 | `xmind_get_topic_properties` | Return one topic's metadata as JSON (notes, markers, boundaries, sheet relationships for that topic, child counts); use to verify writes. |
-| `xmind_search_topics`        | Search for topics by keyword; returns matching topics with their IDs and context. |
-| `xmind_find_topic`         | Find a single topic by exact title; returns its ID and immediate context.         |
+| `xmind_search_topics`        | Search for topics by keyword; returns matching topics with their IDs and context.                                                         |
+| `xmind_find_topic`           | Find a single topic by exact title; returns its ID and immediate context.                                                                 |
 
 ### Tier 3: Topic Mutations
 
@@ -123,20 +123,21 @@ Most tools here target a topic and take a `topic_id` from Tier 2 (or from
 prior results). A few use other ids (`from_id`/`to_id`, `relationship_id`,
 etc.)—see each row.
 
-| Tool                         | Description                                                                   |
-|------------------------------|-------------------------------------------------------------------------------|
-| `xmind_add_topic`            | Add a new child topic under a specified parent.                               |
-| `xmind_add_topics_bulk`      | Add multiple topics (flat list or nested subtree) under a parent in one call. |
-| `xmind_rename_topic`         | Change the title of an existing topic.                                        |
-| `xmind_delete_topic`         | Remove a topic and all its descendants.                                       |
-| `xmind_move_topic`           | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append). |
-| `xmind_reorder_children`     | Change the order of a topic's children without reparenting.                   |
+| Tool                         | Description                                                                                                  |
+|------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `xmind_add_topic`            | Add a new child topic under a specified parent.                                                              |
+| `xmind_add_topics_bulk`      | Add multiple topics (flat list or nested subtree) under a parent in one call.                                |
+| `xmind_duplicate_topic`      | Deep-clone a topic subtree under another parent (same sheet); sheet relationships are not copied.            |
+| `xmind_rename_topic`         | Change the title of an existing topic.                                                                       |
+| `xmind_delete_topic`         | Remove a topic and all its descendants.                                                                      |
+| `xmind_move_topic`           | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append).       |
+| `xmind_reorder_children`     | Change the order of a topic's children without reparenting.                                                  |
 | `xmind_set_topic_properties` | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool. |
-| `xmind_add_floating_topic`   | Add a detached floating topic not connected to the main hierarchy.            |
-| `xmind_add_relationship`     | Draw a labeled connector between any two topics.                              |
-| `xmind_delete_relationship`  | Remove a relationship by id (from `xmind_list_relationships`).                |
-| `xmind_add_summary`          | Add a summary callout bracketing a range of sibling topics.                   |
-| `xmind_add_boundary`         | Add a visual boundary enclosure around all children of a topic.               |
+| `xmind_add_floating_topic`   | Add a detached floating topic not connected to the main hierarchy.                                           |
+| `xmind_add_relationship`     | Draw a labeled connector between any two topics.                                                             |
+| `xmind_delete_relationship`  | Remove a relationship by id (from `xmind_list_relationships`).                                               |
+| `xmind_add_summary`          | Add a summary callout bracketing a range of sibling topics.                                                  |
+| `xmind_add_boundary`         | Add a visual boundary enclosure around all children of a topic.                                              |
 
 ### Tier 4: Utilities
 

--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -2,10 +2,12 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/google/uuid"
 	"github.com/mab-go/xmind-mcp/internal/xmind"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -44,6 +46,60 @@ func countTopics(t *xmind.Topic) int {
 		n += countTopics(&t.Children.Summary[i])
 	}
 	return n
+}
+
+// deepCloneTopic returns a deep copy of the topic subtree with JSON round-trip (preserves codec `extra`
+// data), then assigns fresh UUIDs to every topic and to summary/boundary descriptors within the clone.
+func deepCloneTopic(root *xmind.Topic) (xmind.Topic, error) {
+	if root == nil {
+		return xmind.Topic{}, fmt.Errorf("deepCloneTopic: nil root")
+	}
+	data, err := json.Marshal(root)
+	if err != nil {
+		return xmind.Topic{}, fmt.Errorf("marshal topic: %w", err)
+	}
+	var clone xmind.Topic
+	if err := json.Unmarshal(data, &clone); err != nil {
+		return xmind.Topic{}, fmt.Errorf("unmarshal topic: %w", err)
+	}
+	if err := remapClonedTopicIDs(&clone); err != nil {
+		return xmind.Topic{}, err
+	}
+	return clone, nil
+}
+
+// remapClonedTopicIDs reassigns topic IDs and summary/boundary IDs after a JSON clone. Pass 1 fills
+// idMap; pass 2 updates Summary and Boundary records that reference topic IDs or need unique IDs.
+func remapClonedTopicIDs(root *xmind.Topic) error {
+	idMap := make(map[string]string)
+	walkTopics(root, 0, nil, func(t *xmind.Topic, _ int, _ *xmind.Topic) bool {
+		oldID := t.ID
+		newID := uuid.New().String()
+		idMap[oldID] = newID
+		t.ID = newID
+		return true
+	})
+	var remapErr error
+	walkTopics(root, 0, nil, func(t *xmind.Topic, _ int, _ *xmind.Topic) bool {
+		for i := range t.Summaries {
+			s := &t.Summaries[i]
+			oldTopicRef := s.TopicID
+			s.ID = uuid.New().String()
+			if oldTopicRef != "" {
+				newRef, ok := idMap[oldTopicRef]
+				if !ok {
+					remapErr = fmt.Errorf("clone topic: summary topicId %q not found in cloned subtree", oldTopicRef)
+					return false
+				}
+				s.TopicID = newRef
+			}
+		}
+		for i := range t.Boundaries {
+			t.Boundaries[i].ID = uuid.New().String()
+		}
+		return true
+	})
+	return remapErr
 }
 
 // findSheetByID returns the sheet with the given id, or nil if not found.

--- a/internal/server/handler/handler_test.go
+++ b/internal/server/handler/handler_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mab-go/xmind-mcp/internal/xmind"
+)
+
+func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
+	summaryTopicID := uuid.New().String()
+	root := &xmind.Topic{
+		ID: "root-old",
+		Boundaries: []xmind.Boundary{
+			{ID: "bound-old", Range: "(0,0)"},
+		},
+		Summaries: []xmind.Summary{
+			{ID: "sum-old", Range: "(0,1)", TopicID: summaryTopicID},
+		},
+		Children: &xmind.Children{
+			Attached: []xmind.Topic{{ID: "a-old", Title: "A"}},
+			Summary:  []xmind.Topic{{ID: summaryTopicID, Title: "Sum"}},
+		},
+	}
+	clone, err := deepCloneTopic(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clone.ID == root.ID {
+		t.Fatal("root id should change")
+	}
+	if len(clone.Children.Attached) != 1 || clone.Children.Attached[0].ID == "a-old" {
+		t.Fatalf("attached child id should change: %+v", clone.Children.Attached[0])
+	}
+	if len(clone.Children.Summary) != 1 || clone.Children.Summary[0].ID == summaryTopicID {
+		t.Fatalf("summary topic id should change: %+v", clone.Children.Summary[0])
+	}
+	if clone.Boundaries[0].ID == "bound-old" || clone.Boundaries[0].Range != "(0,0)" {
+		t.Fatalf("boundary: want new id and preserved range, got %+v", clone.Boundaries[0])
+	}
+	if clone.Summaries[0].ID == "sum-old" {
+		t.Fatal("summary descriptor id should change")
+	}
+	if clone.Summaries[0].TopicID != clone.Children.Summary[0].ID {
+		t.Fatalf("Summary.TopicID %q should equal summary topic id %q",
+			clone.Summaries[0].TopicID, clone.Children.Summary[0].ID)
+	}
+	if clone.Summaries[0].Range != "(0,1)" {
+		t.Fatalf("summary range should be preserved, got %q", clone.Summaries[0].Range)
+	}
+}

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -375,6 +375,80 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 	return textResult(fmt.Sprintf("added topic id %s", topic.ID)), nil
 }
 
+// DuplicateTopic deep-clones a topic subtree and attaches it as an attached child of target_parent_id.
+func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	args := req.GetArguments()
+	absPath, toolErr := absPathFromArgs(args)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	sheetID, terr := requireString(args, "sheet_id")
+	if terr != nil {
+		return terr, nil
+	}
+	topicID, terr := requireString(args, "topic_id")
+	if terr != nil {
+		return terr, nil
+	}
+	targetParentID, terr := requireString(args, "target_parent_id")
+	if terr != nil {
+		return terr, nil
+	}
+	pos, perr := parsePositionOptional(args["position"])
+	if perr != nil {
+		return perr, nil
+	}
+
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if toolErr2 != nil {
+		return toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+	source := findTopicByID(&sh.RootTopic, topicID)
+	if source == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("source topic not found: %s", topicID)), nil
+	}
+	targetParent := findTopicByID(&sh.RootTopic, targetParentID)
+	if targetParent == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("target parent not found: %s", targetParentID)), nil
+	}
+
+	clone, err := deepCloneTopic(source)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate topic: %w", err)
+	}
+	newRootID := clone.ID
+	n := countTopics(&clone)
+
+	if terr := insertAttached(targetParent, clone, pos); terr != nil {
+		return terr, nil
+	}
+	insertIdx := 0
+	if pos == nil {
+		insertIdx = len(targetParent.Children.Attached) - 1
+	} else {
+		insertIdx = *pos
+	}
+	if len(targetParent.Summaries) > 0 {
+		adjustSummariesAfterAttachedInsert(targetParent, insertIdx)
+	}
+	sh.RevisionID = uuid.New().String()
+	if err := xmind.WriteMap(absPath, sheets); err != nil {
+		return nil, fmt.Errorf("write map: %w", err)
+	}
+	return textResult(fmt.Sprintf(
+		"duplicated topic %s as %s under %s (%d topics copied)",
+		topicID, newRootID, targetParentID, n,
+	)), nil
+}
+
 // AddTopicsBulk adds a nested tree under parent_id.
 func (h *XMindHandler) AddTopicsBulk(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -1420,6 +1420,184 @@ func TestSetTopicPropertiesMultilineNoteHTML(t *testing.T) {
 	}
 }
 
+func TestDuplicateTopicHappyPath(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dup.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	mid := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Mid",
+	})), "added topic id ")
+	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": mid, "title": "Leaf"})
+	res := callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": mid, "target_parent_id": rid,
+	})
+	if res.IsError {
+		t.Fatalf("DuplicateTopic: %s", textContent(t, res))
+	}
+	msg := textContent(t, res)
+	var oldID, newID, parentID string
+	var n int
+	_, scanErr := fmt.Sscanf(msg, "duplicated topic %s as %s under %s (%d topics copied)", &oldID, &newID, &parentID, &n)
+	if scanErr != nil || oldID != mid || parentID != rid || n != 2 {
+		t.Fatalf("unexpected message: %q (scanErr=%v)", msg, scanErr)
+	}
+	if newID == mid {
+		t.Fatalf("expected new root id to differ from source: %s", newID)
+	}
+	sheets, err = xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := &sheets[0].RootTopic
+	if root.Children == nil || len(root.Children.Attached) != 2 {
+		t.Fatalf("want 2 attached children on root (original Mid + duplicate), got %+v", root.Children)
+	}
+	if root.Children.Attached[0].ID != mid {
+		t.Fatalf("first child should be original Mid %s", mid)
+	}
+	if root.Children.Attached[1].ID != newID {
+		t.Fatalf("second child should be duplicate root %s, got %s", newID, root.Children.Attached[1].ID)
+	}
+	if root.Children.Attached[1].Title != "Mid" {
+		t.Fatalf("duplicate title: %+v", root.Children.Attached[1])
+	}
+	if root.Children.Attached[1].Children == nil || len(root.Children.Attached[1].Children.Attached) != 1 ||
+		root.Children.Attached[1].Children.Attached[0].Title != "Leaf" {
+		t.Fatalf("duplicate should include Leaf: %+v", root.Children.Attached[1].Children)
+	}
+}
+
+func TestDuplicateTopicPositionInsertAtZeroAndAppend(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "duppos.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": "A"})
+	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": "B"})
+	src := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Src",
+	})), "added topic id ")
+	callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": src, "target_parent_id": rid, "position": float64(0),
+	})
+	sheets, _ = xmind.ReadMap(path)
+	ch := sheets[0].RootTopic.Children.Attached
+	if len(ch) != 4 || ch[0].Title != "Src" || ch[1].Title != "A" {
+		t.Fatalf("want Src first after insert at 0, got titles %v", topicTitles(ch))
+	}
+
+	// Append: omit position — duplicate should be last; duplicate root id must differ from original Src.
+	callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": src, "target_parent_id": rid,
+	})
+	sheets, _ = xmind.ReadMap(path)
+	ch = sheets[0].RootTopic.Children.Attached
+	if len(ch) != 5 || ch[4].Title != "Src" || ch[4].ID == src || ch[3].ID != src {
+		t.Fatalf("want original Src at index 3 and appended duplicate at index 4, got titles %v ids last=%s src=%s",
+			topicTitles(ch), ch[4].ID, src)
+	}
+}
+
+func topicTitles(topics []xmind.Topic) []string {
+	var s []string
+	for i := range topics {
+		s = append(s, topics[i].Title)
+	}
+	return s
+}
+
+func TestDuplicateTopicErrors(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "duperr.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	child := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "C",
+	})), "added topic id ")
+
+	res := callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": "00000000-0000-0000-0000-000000000099", "topic_id": child, "target_parent_id": rid,
+	})
+	if !res.IsError || !strings.Contains(textContent(t, res), "sheet not found") {
+		t.Fatalf("expected sheet not found, got %v %q", res.IsError, textContent(t, res))
+	}
+	res = callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": "00000000-0000-0000-0000-000000000099", "target_parent_id": rid,
+	})
+	if !res.IsError || !strings.Contains(textContent(t, res), "source topic not found") {
+		t.Fatalf("expected source topic not found, got %q", textContent(t, res))
+	}
+	res = callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": child, "target_parent_id": "00000000-0000-0000-0000-000000000099",
+	})
+	if !res.IsError || !strings.Contains(textContent(t, res), "target parent not found") {
+		t.Fatalf("expected target parent not found, got %q", textContent(t, res))
+	}
+	res = callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": child, "target_parent_id": rid, "position": float64(99),
+	})
+	if !res.IsError || !strings.Contains(textContent(t, res), "out of range") {
+		t.Fatalf("expected position out of range, got %q", textContent(t, res))
+	}
+}
+
+func TestDuplicateTopicKitchenSinkSummariesSmoke(t *testing.T) {
+	h := NewXMindHandler()
+	path := copyFixture(t, kitchenSinkPath(t))
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var summarySheetID, summaryTopicID string
+outer:
+	for si := range sheets {
+		sh := &sheets[si]
+		walkTopics(&sh.RootTopic, 0, nil, func(topic *xmind.Topic, _ int, _ *xmind.Topic) bool {
+			if len(topic.Summaries) > 0 {
+				summarySheetID = sh.ID
+				summaryTopicID = topic.ID
+				return false
+			}
+			return true
+		})
+		if summarySheetID != "" {
+			break outer
+		}
+	}
+	if summarySheetID == "" || summaryTopicID == "" {
+		t.Fatal("fixture must include a topic with summaries")
+	}
+	sh := findSheetByID(sheets, summarySheetID)
+	if sh == nil {
+		t.Fatal("sheet not found")
+	}
+	rootID := sh.RootTopic.ID
+	res := callTool(t, h.DuplicateTopic, map[string]any{
+		"path": path, "sheet_id": summarySheetID, "topic_id": summaryTopicID, "target_parent_id": rootID,
+	})
+	if res.IsError {
+		t.Fatalf("DuplicateTopic: %s", textContent(t, res))
+	}
+	sheets, err = xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sheets // round-trip succeeded
+}
+
 func TestWalkTopicsStopsOnSiblings(t *testing.T) {
 	// Regression: early stop must not continue into later sibling subtrees.
 	root := &xmind.Topic{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,6 +39,7 @@ func newXMindServer(ctx context.Context, h *handler.XMindHandler) *mcpserver.MCP
 	s.AddTool(toolFindTopic, h.FindTopic)
 	s.AddTool(toolAddTopic, h.AddTopic)
 	s.AddTool(toolAddTopicsBulk, h.AddTopicsBulk)
+	s.AddTool(toolDuplicateTopic, h.DuplicateTopic)
 	s.AddTool(toolRenameTopic, h.RenameTopic)
 	s.AddTool(toolDeleteTopic, h.DeleteTopic)
 	s.AddTool(toolMoveTopic, h.MoveTopic)

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -118,6 +118,19 @@ var toolAddTopicsBulk = mcp.NewTool(
 	mcp.WithArray("topics", mcp.Required(), mcp.Description(`Array of {title, children?} objects`)),
 )
 
+var toolDuplicateTopic = mcp.NewTool(
+	"xmind_duplicate_topic",
+	mcp.WithDescription(
+		"Deep-clone a topic and its subtree (same sheet only) and attach the copy as an attached child of target_parent_id. "+
+			"Sheet-level relationships are not copied. Hyperlinks or note text that reference other topic IDs by ID are not rewritten and may still point at the original topics.",
+	),
+	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
+	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet containing the source topic")),
+	mcp.WithString("topic_id", mcp.Required(), mcp.Description("Root topic of the subtree to duplicate")),
+	mcp.WithString("target_parent_id", mcp.Required(), mcp.Description("Parent topic to attach the copy under (attached children)")),
+	mcp.WithNumber("position", mcp.Description("Zero-based index among the parent's attached children; omit to append")),
+)
+
 var toolRenameTopic = mcp.NewTool(
 	"xmind_rename_topic",
 	mcp.WithDescription("Rename an existing topic."),


### PR DESCRIPTION
This commit lets callers deep-copy a topic subtree under another parent on the same sheet, instead of recreating repeated structures with add-topic calls. Cloning uses JSON round-trip to preserve codec `extra` data, then reassigns topic, summary, and boundary ids so the copy is self-consistent. Sheet-level relationships are not duplicated.

Features:
- Add `xmind_duplicate_topic` in `tools.go` and register in `server.go`
- Add `DuplicateTopic` handler and `deepCloneTopic` / `remapClonedTopicIDs` in `handler.go`
- Return distinct tool errors for missing source topic vs target parent

Tests:
- Handler integration tests (happy path, errors, position insert vs append, kitchen-sink summaries smoke)
- `handler_test.go` unit test for summary/boundary remap invariants

Docs:
- Update README tool count and Tier 3 table; document `deepCloneTopic` in `AGENTS.md`

Closes #12