### PR TITLE
Add xmind_set_topic_properties_bulk tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server for
 reading and writing local [XMind](https://xmind.com) mind map files. XMind MCP
-exposes 26 tools that let any MCP-compatible AI client create, navigate, and
+exposes 27 tools that let any MCP-compatible AI client create, navigate, and
 edit `.xmind` files directly on disk.
 
 <p align="center">
@@ -123,21 +123,22 @@ Most tools here target a topic and take a `topic_id` from Tier 2 (or from
 prior results). A few use other ids (`from_id`/`to_id`, `relationship_id`,
 etc.)—see each row.
 
-| Tool                         | Description                                                                                                  |
-|------------------------------|--------------------------------------------------------------------------------------------------------------|
-| `xmind_add_topic`            | Add a new child topic under a specified parent.                                                              |
-| `xmind_add_topics_bulk`      | Add multiple topics (flat list or nested subtree) under a parent in one call.                                |
-| `xmind_duplicate_topic`      | Deep-clone a topic subtree under another parent (same sheet); sheet relationships are not copied.            |
-| `xmind_rename_topic`         | Change the title of an existing topic.                                                                       |
-| `xmind_delete_topic`         | Remove a topic and all its descendants.                                                                      |
-| `xmind_move_topic`           | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append).       |
-| `xmind_reorder_children`     | Change the order of a topic's children without reparenting.                                                  |
-| `xmind_set_topic_properties` | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool. |
-| `xmind_add_floating_topic`   | Add a detached floating topic not connected to the main hierarchy.                                           |
-| `xmind_add_relationship`     | Draw a labeled connector between any two topics.                                                             |
-| `xmind_delete_relationship`  | Remove a relationship by id (from `xmind_list_relationships`).                                               |
-| `xmind_add_summary`          | Add a summary callout bracketing a range of sibling topics.                                                  |
-| `xmind_add_boundary`         | Add a visual boundary enclosure around all children of a topic.                                              |
+| Tool                              | Description                                                                                                  |
+|-----------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `xmind_add_topic`                 | Add a new child topic under a specified parent.                                                              |
+| `xmind_add_topics_bulk`           | Add multiple topics (flat list or nested subtree) under a parent in one call.                                |
+| `xmind_duplicate_topic`           | Deep-clone a topic subtree under another parent (same sheet); sheet relationships are not copied.            |
+| `xmind_rename_topic`              | Change the title of an existing topic.                                                                       |
+| `xmind_delete_topic`              | Remove a topic and all its descendants.                                                                      |
+| `xmind_move_topic`                | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append).       |
+| `xmind_reorder_children`          | Change the order of a topic's children without reparenting.                                                  |
+| `xmind_set_topic_properties`      | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool. |
+| `xmind_set_topic_properties_bulk` | Apply the same metadata updates as `xmind_set_topic_properties` to many topic IDs in one read/write.         |
+| `xmind_add_floating_topic`        | Add a detached floating topic not connected to the main hierarchy.                                           |
+| `xmind_add_relationship`          | Draw a labeled connector between any two topics.                                                             |
+| `xmind_delete_relationship`       | Remove a relationship by id (from `xmind_list_relationships`).                                               |
+| `xmind_add_summary`               | Add a summary callout bracketing a range of sibling topics.                                                  |
+| `xmind_add_boundary`              | Add a visual boundary enclosure around all children of a topic.                                              |
 
 ### Tier 4: Utilities
 

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -762,6 +762,115 @@ func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequ
 	return textResult(fmt.Sprintf("reordered %d children under %s", len(newOrder), parentID)), nil
 }
 
+// hasActionableTopicPropertyArgs reports whether bulk set-topic-properties has at least one
+// property argument that would run a mutating branch (same rules as the single-topic tool).
+func hasActionableTopicPropertyArgs(args map[string]any) bool {
+	if _, has := args["notes"]; has {
+		return true
+	}
+	if v, has := args["labels"]; has && v != nil {
+		return true
+	}
+	if v, has := args["markers"]; has && v != nil {
+		return true
+	}
+	if v, has := args["link"]; has && v != nil {
+		return true
+	}
+	if v, has := args["remove_markers"]; has && v != nil {
+		arr, ok := v.([]any)
+		if !ok {
+			return true // invalid type — apply will error
+		}
+		return len(arr) > 0
+	}
+	return false
+}
+
+// applyTopicPropertiesArgs applies notes, labels, markers, remove_markers, and link from args
+// to topic using the same semantics as xmind_set_topic_properties.
+func applyTopicPropertiesArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
+	if v, has := args["notes"]; has {
+		if v == nil {
+			topic.Notes = nil
+		} else {
+			s, ok := v.(string)
+			if !ok {
+				return mcp.NewToolResultError("invalid argument notes: expected a string")
+			}
+			if s == "" {
+				topic.Notes = nil
+			} else {
+				topic.Notes = &xmind.Notes{
+					Plain:    &xmind.NoteContent{Content: s},
+					RealHTML: &xmind.NoteContent{Content: plainToRealHTML(s)},
+				}
+			}
+		}
+	}
+	if v, has := args["labels"]; has && v != nil {
+		arr, ok := v.([]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid argument labels: expected an array")
+		}
+		labels := make([]string, 0, len(arr))
+		for i, el := range arr {
+			s, ok := el.(string)
+			if !ok {
+				return mcp.NewToolResultError(fmt.Sprintf("labels[%d]: expected string", i))
+			}
+			labels = append(labels, s)
+		}
+		topic.Labels = labels
+	}
+	if v, has := args["markers"]; has && v != nil {
+		arr, ok := v.([]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid argument markers: expected an array")
+		}
+		markers := make([]xmind.Marker, 0, len(arr))
+		for i, el := range arr {
+			s, ok := el.(string)
+			if !ok {
+				return mcp.NewToolResultError(fmt.Sprintf("markers[%d]: expected string", i))
+			}
+			markers = append(markers, xmind.Marker{MarkerID: s})
+		}
+		topic.Markers = markers
+	}
+	if v, has := args["remove_markers"]; has && v != nil {
+		arr, ok := v.([]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid argument remove_markers: expected an array")
+		}
+		if len(arr) > 0 {
+			remove := make(map[string]struct{}, len(arr))
+			for i, el := range arr {
+				s, ok := el.(string)
+				if !ok {
+					return mcp.NewToolResultError(fmt.Sprintf("remove_markers[%d]: expected string", i))
+				}
+				remove[s] = struct{}{}
+			}
+			out := make([]xmind.Marker, 0, len(topic.Markers))
+			for _, m := range topic.Markers {
+				if _, drop := remove[m.MarkerID]; !drop {
+					out = append(out, m)
+				}
+			}
+			topic.Markers = out
+		}
+	}
+	if v, has := args["link"]; has && v != nil {
+		s, ok := v.(string)
+		if !ok {
+			return mcp.NewToolResultError("invalid argument link: expected a string")
+		}
+		topic.Href = s
+	}
+	return nil
+}
+
 // SetTopicProperties updates optional metadata on a topic.
 func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
@@ -795,83 +904,8 @@ func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolR
 		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
 	}
 
-	if v, has := args["notes"]; has {
-		if v == nil {
-			topic.Notes = nil
-		} else {
-			s, ok := v.(string)
-			if !ok {
-				return mcp.NewToolResultError("invalid argument notes: expected a string"), nil
-			}
-			if s == "" {
-				topic.Notes = nil
-			} else {
-				topic.Notes = &xmind.Notes{
-					Plain:    &xmind.NoteContent{Content: s},
-					RealHTML: &xmind.NoteContent{Content: plainToRealHTML(s)},
-				}
-			}
-		}
-	}
-	if v, has := args["labels"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument labels: expected an array"), nil
-		}
-		labels := make([]string, 0, len(arr))
-		for i, el := range arr {
-			s, ok := el.(string)
-			if !ok {
-				return mcp.NewToolResultError(fmt.Sprintf("labels[%d]: expected string", i)), nil
-			}
-			labels = append(labels, s)
-		}
-		topic.Labels = labels
-	}
-	if v, has := args["markers"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument markers: expected an array"), nil
-		}
-		markers := make([]xmind.Marker, 0, len(arr))
-		for i, el := range arr {
-			s, ok := el.(string)
-			if !ok {
-				return mcp.NewToolResultError(fmt.Sprintf("markers[%d]: expected string", i)), nil
-			}
-			markers = append(markers, xmind.Marker{MarkerID: s})
-		}
-		topic.Markers = markers
-	}
-	if v, has := args["remove_markers"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument remove_markers: expected an array"), nil
-		}
-		if len(arr) > 0 {
-			remove := make(map[string]struct{}, len(arr))
-			for i, el := range arr {
-				s, ok := el.(string)
-				if !ok {
-					return mcp.NewToolResultError(fmt.Sprintf("remove_markers[%d]: expected string", i)), nil
-				}
-				remove[s] = struct{}{}
-			}
-			out := make([]xmind.Marker, 0, len(topic.Markers))
-			for _, m := range topic.Markers {
-				if _, drop := remove[m.MarkerID]; !drop {
-					out = append(out, m)
-				}
-			}
-			topic.Markers = out
-		}
-	}
-	if v, has := args["link"]; has && v != nil {
-		s, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument link: expected a string"), nil
-		}
-		topic.Href = s
+	if toolResult := applyTopicPropertiesArgs(args, topic); toolResult != nil {
+		return toolResult, nil
 	}
 
 	sh.RevisionID = uuid.New().String()
@@ -879,6 +913,88 @@ func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolR
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("updated topic %s", topicID)), nil
+}
+
+// SetTopicPropertiesBulk updates optional metadata on multiple topics in a single read/write cycle.
+func (h *XMindHandler) SetTopicPropertiesBulk(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	args := req.GetArguments()
+	absPath, toolErr := absPathFromArgs(args)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	sheetID, terr := requireString(args, "sheet_id")
+	if terr != nil {
+		return terr, nil
+	}
+
+	raw, has := args["topic_ids"]
+	if !has {
+		return mcp.NewToolResultError("missing required argument: topic_ids"), nil
+	}
+	rawIDs, ok := raw.([]any)
+	if !ok {
+		return mcp.NewToolResultError("invalid argument topic_ids: expected an array"), nil
+	}
+	topicIDs := make([]string, 0, len(rawIDs))
+	seen := make(map[string]struct{}, len(rawIDs))
+	for i, v := range rawIDs {
+		s, ok := v.(string)
+		if !ok || s == "" {
+			return mcp.NewToolResultError(fmt.Sprintf("topic_ids[%d]: expected non-empty string", i)), nil
+		}
+		if _, dup := seen[s]; dup {
+			return mcp.NewToolResultError(fmt.Sprintf("duplicate id in topic_ids: %s", s)), nil
+		}
+		seen[s] = struct{}{}
+		topicIDs = append(topicIDs, s)
+	}
+	if len(topicIDs) == 0 {
+		return mcp.NewToolResultError("topic_ids must be non-empty"), nil
+	}
+
+	if !hasActionableTopicPropertyArgs(args) {
+		return mcp.NewToolResultError("missing property updates: provide at least one of notes, labels, markers, remove_markers, or link"), nil
+	}
+
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if toolErr2 != nil {
+		return toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+
+	topics := make([]*xmind.Topic, 0, len(topicIDs))
+	missing := make([]string, 0)
+	for _, id := range topicIDs {
+		t := findTopicByID(&sh.RootTopic, id)
+		if t == nil {
+			missing = append(missing, id)
+		} else {
+			topics = append(topics, t)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", strings.Join(missing, ", "))), nil
+	}
+
+	for _, topic := range topics {
+		if toolResult := applyTopicPropertiesArgs(args, topic); toolResult != nil {
+			return toolResult, nil
+		}
+	}
+
+	sh.RevisionID = uuid.New().String()
+	if err := xmind.WriteMap(absPath, sheets); err != nil {
+		return nil, fmt.Errorf("write map: %w", err)
+	}
+	return textResult(fmt.Sprintf("updated %d topics", len(topicIDs))), nil
 }
 
 // AddFloatingTopic adds a detached topic on the sheet root.

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -1420,6 +1420,310 @@ func TestSetTopicPropertiesMultilineNoteHTML(t *testing.T) {
 	}
 }
 
+func TestSetTopicPropertiesBulkHappyPath(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkhp.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	id1 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "One",
+	})), "added topic id ")
+	id2 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Two",
+	})), "added topic id ")
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path":      path,
+		"sheet_id":  sid,
+		"topic_ids": []any{id1, id2},
+		"labels":    []any{"bulk-a", "bulk-b"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	if got := textContent(t, res); got != "updated 2 topics" {
+		t.Fatalf("message: got %q want %q", got, "updated 2 topics")
+	}
+	sheets, _ = xmind.ReadMap(path)
+	root := &sheets[0].RootTopic
+	for _, id := range []string{id1, id2} {
+		topic := findTopicByID(root, id)
+		if topic == nil {
+			t.Fatalf("topic %s not found", id)
+		}
+		if len(topic.Labels) != 2 || topic.Labels[0] != "bulk-a" || topic.Labels[1] != "bulk-b" {
+			t.Fatalf("topic %s labels: %v", id, topic.Labels)
+		}
+	}
+}
+
+func TestSetTopicPropertiesBulkMarkersAndRemoveMarkers(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkmm.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	id1 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "One",
+	})), "added topic id ")
+	id2 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Two",
+	})), "added topic id ")
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path":      path,
+		"sheet_id":  sid,
+		"topic_ids": []any{id1, id2},
+		"markers":   []any{"priority-1", "task-done"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	res = callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path":           path,
+		"sheet_id":       sid,
+		"topic_ids":      []any{id1, id2},
+		"remove_markers": []any{"priority-1"},
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	sheets, _ = xmind.ReadMap(path)
+	root := &sheets[0].RootTopic
+	for _, id := range []string{id1, id2} {
+		topic := findTopicByID(root, id)
+		if topic == nil {
+			t.Fatalf("topic %s not found", id)
+		}
+		if len(topic.Markers) != 1 || topic.Markers[0].MarkerID != "task-done" {
+			t.Fatalf("topic %s markers: %+v", id, topic.Markers)
+		}
+	}
+}
+
+func TestSetTopicPropertiesBulkEmptyTopicIDs(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkempty.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": []any{},
+		"notes": "x",
+	})
+	if !res.IsError {
+		t.Fatal("expected error for empty topic_ids")
+	}
+	if msg := textContent(t, res); !strings.Contains(msg, "topic_ids must be non-empty") {
+		t.Fatalf("empty topic_ids: got %q", msg)
+	}
+	res = callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "notes": "x",
+	})
+	if !res.IsError {
+		t.Fatal("expected error when topic_ids is missing")
+	}
+	if msg := textContent(t, res); !strings.Contains(msg, "missing required argument: topic_ids") {
+		t.Fatalf("missing topic_ids: got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkTopicIDsWrongType(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulktype.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": float64(1), "labels": []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error when topic_ids is not an array")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "invalid argument topic_ids: expected an array") {
+		t.Fatalf("got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkTopicIDEmptyString(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkemptystr.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	tid := sheets[0].RootTopic.ID
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": []any{tid, ""}, "labels": []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error for empty string in topic_ids")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "topic_ids[1]: expected non-empty string") {
+		t.Fatalf("got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkTopicIDNonString(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulknonstr.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	tid := sheets[0].RootTopic.ID
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": []any{tid, 42}, "labels": []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error for non-string topic_ids element")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "topic_ids[1]: expected non-empty string") {
+		t.Fatalf("got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkSingleMissingID(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkonemiss.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	miss := "00000000-0000-0000-0000-00000000dead"
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": []any{miss}, "labels": []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error for missing topic")
+	}
+	msg := textContent(t, res)
+	if !strings.HasPrefix(msg, "topic not found: ") || !strings.Contains(msg, miss) {
+		t.Fatalf("got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkDuplicateTopicIDs(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkdup.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	tid := sheets[0].RootTopic.ID
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path":      path,
+		"sheet_id":  sid,
+		"topic_ids": []any{tid, tid},
+		"labels":    []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error for duplicate topic_ids")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "duplicate id in topic_ids") {
+		t.Fatalf("expected duplicate error, got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkMultipleMissingIDs(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulkmiss.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	m1 := "00000000-0000-0000-0000-000000000003"
+	m2 := "00000000-0000-0000-0000-000000000001"
+	m3 := "00000000-0000-0000-0000-000000000002"
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path":      path,
+		"sheet_id":  sid,
+		"topic_ids": []any{m1, m2, m3},
+		"labels":    []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error for missing topics")
+	}
+	msg := textContent(t, res)
+	if !strings.HasPrefix(msg, "topic not found: ") {
+		t.Fatalf("error message: got %q", msg)
+	}
+	for _, id := range []string{m1, m2, m3} {
+		if !strings.Contains(msg, id) {
+			t.Fatalf("error message missing %s: %q", id, msg)
+		}
+	}
+}
+
+func TestSetTopicPropertiesBulkSheetNotFound(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulksh.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	tid := sheets[0].RootTopic.ID
+	badSheet := "00000000-0000-0000-0000-00000000dead"
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path":      path,
+		"sheet_id":  badSheet,
+		"topic_ids": []any{tid},
+		"labels":    []any{"x"},
+	})
+	if !res.IsError {
+		t.Fatal("expected error for unknown sheet")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "sheet not found:") || !strings.Contains(msg, badSheet) {
+		t.Fatalf("error message: got %q", msg)
+	}
+}
+
+func TestSetTopicPropertiesBulkNoActionableProperty(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulknoact.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	tid := sheets[0].RootTopic.ID
+
+	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": []any{tid},
+	})
+	if !res.IsError {
+		t.Fatal("expected error when no property updates")
+	}
+	res = callTool(t, h.SetTopicPropertiesBulk, map[string]any{
+		"path": path, "sheet_id": sid, "topic_ids": []any{tid}, "labels": nil,
+	})
+	if !res.IsError {
+		t.Fatal("expected error when only labels:null")
+	}
+	msg := textContent(t, res)
+	if !strings.Contains(msg, "missing property updates") {
+		t.Fatalf("expected missing property updates, got %q", msg)
+	}
+}
+
 func TestDuplicateTopicHappyPath(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ func newXMindServer(ctx context.Context, h *handler.XMindHandler) *mcpserver.MCP
 	s.AddTool(toolMoveTopic, h.MoveTopic)
 	s.AddTool(toolReorderChildren, h.ReorderChildren)
 	s.AddTool(toolSetTopicProperties, h.SetTopicProperties)
+	s.AddTool(toolSetTopicPropertiesBulk, h.SetTopicPropertiesBulk)
 	s.AddTool(toolAddFloatingTopic, h.AddFloatingTopic)
 	s.AddTool(toolAddRelationship, h.AddRelationship)
 	s.AddTool(toolListRelationships, h.ListRelationships)

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -186,6 +186,23 @@ var toolSetTopicProperties = mcp.NewTool(
 	mcp.WithString("link", mcp.Description("URL, file path, or topic link href; empty string clears the link; omit or null leaves the link unchanged")),
 )
 
+var toolSetTopicPropertiesBulk = mcp.NewTool(
+	"xmind_set_topic_properties_bulk",
+	mcp.WithDescription(
+		"Set optional metadata on multiple topics in one read/write: same fields and clearing rules as xmind_set_topic_properties (notes, labels, markers, link, remove_markers). "+
+			"topic_ids must be non-empty with no duplicate IDs; every ID must exist on the sheet. "+
+			"At least one property argument is required. remove_markers is applied after markers when both are set.",
+	),
+	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
+	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
+	mcp.WithArray("topic_ids", mcp.Required(), mcp.Description("Topic IDs to update (non-empty strings, no duplicates)")),
+	mcp.WithString("notes", mcp.Description("Plain text note (plain + HTML fields set); empty string or null clears notes (only this field uses null to clear)")),
+	mcp.WithArray("labels", mcp.Description("List of label strings; empty array clears all labels; omit or null leaves labels unchanged")),
+	mcp.WithArray("markers", mcp.Description(`Full marker ID list, e.g. "priority-1", "task-done"; empty array clears all markers; omit or null leaves markers unchanged`)),
+	mcp.WithArray("remove_markers", mcp.Description(`Marker IDs to remove after any markers replace; empty array removes nothing; omit or null leaves markers unchanged; applied after markers when both are set`)),
+	mcp.WithString("link", mcp.Description("URL, file path, or topic link href; empty string clears the link; omit or null leaves the link unchanged")),
+)
+
 var toolAddFloatingTopic = mcp.NewTool(
 	"xmind_add_floating_topic",
 	mcp.WithDescription("Add a floating (detached) topic on the sheet, positioned under the root topic."),


### PR DESCRIPTION
This commit adds a batch set-topic-properties tool so clients can update notes, labels, markers, remove_markers, and link on many topics in one read/write. Logic is shared with the single-topic handler via applyTopicPropertiesArgs; bulk validates topic_ids before opening the map and resolves every ID before applying changes.

- Register xmind_set_topic_properties_bulk in tools.go and server.go
- Add SetTopicPropertiesBulk, hasActionableTopicPropertyArgs, and applyTopicPropertiesArgs in mutate.go; split topic_ids errors (missing key, wrong type, empty list)
- Document the tool in README and set the tool count to 27
- Add mutate_test.go coverage for bulk paths and validation

Closes #13