### PR TITLE
Add Dockerfile, GHA publish workflow, and Docker docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+bin/
+testdata/
+coverage.out
+coverage.html
+.github/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Docker publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Version metadata
+        run: |
+          echo "VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" >> "$GITHUB_ENV"
+          echo "COMMIT=$(git rev-parse HEAD 2>/dev/null || echo unknown)" >> "$GITHUB_ENV"
+          echo "DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/mab-go/xmind-mcp
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern=v{{version}}
+            type=ref,event=pr
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.COMMIT }}
+            DATE=${{ env.DATE }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ This file is the authoritative briefing for any AI agent working on this project
 ## Project Structure
 
 ```
+Dockerfile                — multi-stage image (Alpine build, distroless runtime)
+.dockerignore             — Docker build context exclusions
+.github/
+  workflows/
+    ci.yml                — test and lint on push and PR
+    docker-publish.yml    — multi-platform image build and push to GHCR
 cmd/
   xmind-mcp/
     main.go               — cobra command; calls server.RunStdioServer()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Builder: compile static binary (CGO disabled).
+FROM golang:1.26.1-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+
+ENV CGO_ENABLED=0
+
+RUN go build \
+	-ldflags "-X github.com/mab-go/xmind-mcp/internal/version.Version=${VERSION} -X github.com/mab-go/xmind-mcp/internal/version.Commit=${COMMIT} -X github.com/mab-go/xmind-mcp/internal/version.Date=${DATE}" \
+	-o /xmind-mcp \
+	./cmd/xmind-mcp
+
+# Runtime: minimal image with only the binary (stdio MCP).
+FROM gcr.io/distroless/static-debian12
+
+LABEL io.modelcontextprotocol.server.name="io.github.mab-go/xmind-mcp"
+
+COPY --from=builder /xmind-mcp /xmind-mcp
+
+ENTRYPOINT ["/xmind-mcp"]

--- a/README.md
+++ b/README.md
@@ -53,8 +53,84 @@ The binary is written to `./bin/xmind-mcp` with version metadata from
 `git` (see the `build` target in the `Makefile`). A plain
 `go build ./cmd/xmind-mcp` also works but omits those ldflags.
 
-> **Note:** Pre-built binaries for all platforms will be available in a
-> future release.
+> **Note:** A multi-platform container image is published to
+> [GHCR](https://github.com/mab-go/xmind-mcp/pkgs/container/xmind-mcp) on
+> each push to `main` and on version tags (see **Docker** below). Pre-built
+> release binaries for all platforms may follow in a future release.
+
+------------------------------------------------------------------------
+
+## Docker
+
+The image `ghcr.io/mab-go/xmind-mcp` runs the same stdio MCP server as the
+host binary. Mount a host directory that contains your `.xmind` files and pass
+paths **as seen inside the container** to the tools (for example, if you mount
+`/home/you/maps` at `/maps`, use `/maps/my-map.xmind` in tool calls).
+
+Build and load locally (single platform):
+
+```bash
+docker buildx build --platform linux/amd64 --load -t xmind-mcp:test .
+```
+
+Optional build arguments (defaults match a local build without git in context):
+
+```bash
+docker buildx build \
+  --platform linux/amd64 \
+  --load \
+  --build-arg VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)" \
+  --build-arg COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)" \
+  --build-arg DATE="$(date -u +%Y-%m-%d)" \
+  -t xmind-mcp:test .
+```
+
+Multi-platform build (no `--load`; suitable for CI or registry push):
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 .
+```
+
+**Linux (amd64 host):** Building the `linux/arm64` variant runs `RUN` steps inside
+an ARM image. Without [QEMU user emulation](https://docs.docker.com/build/building/multi-platform/#qemu),
+those steps fail with `exec format error`. Install binfmt handlers once:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Docker Desktop on macOS and Windows usually includes this. If you only need to
+check that the Dockerfile builds on your machine, use `linux/amd64` only (the
+first command above).
+
+Run interactively (stdio requires `-i`):
+
+```bash
+docker run --rm -i -v /path/on/host:/maps xmind-mcp:test --version
+```
+
+### MCP client configuration (Docker)
+
+For Claude Desktop, run the published image via `docker` and pass mounts in
+`args` (adjust the host path). Example `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "xmind": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        "/path/on/host:/maps",
+        "ghcr.io/mab-go/xmind-mcp:latest"
+      ]
+    }
+  }
+}
+```
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit adds the OCI image infrastructure required to list xmind-mcp in the MCP Registry and the Docker MCP Registry.

Changes:
- `Dockerfile`: multi-stage build (Alpine builder, distroless runtime) with VERSION/COMMIT/DATE build args and the required MCP server label
- `.dockerignore`: excludes `.git/`, `bin/`, `testdata/`, and build artifacts from the build context
- `.github/workflows/docker-publish.yml`: builds and pushes a multi-platform (linux/amd64, linux/arm64) image to GHCR on pushes to main and version tags; build-only on PRs targeting main
- `AGENTS.md`: updated project structure tree to reflect new files
- `README.md`: added Docker section with local build instructions, optional build-arg examples, multi-platform build command, standalone run example, and Claude Desktop config snippet

Closes #17