### PR TITLE
Return structured JSON from topic mutation tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ internal/
     tools.go              — tool definitions as package-level var declarations
     hooks.go              — MCP lifecycle hooks (before/after initialize)
     handler/
-      handler.go          — XMindHandler struct and shared utilities (textResult, etc.)
+      handler.go          — XMindHandler struct and shared utilities (textResult, jsonResult, etc.)
       handler_test.go     — tests for handler helpers (e.g. deepCloneTopic)
       sheets.go           — handlers for Tier 1: file & sheet management tools
       find.go             — handlers for Tier 2: search/find tools
@@ -176,6 +176,18 @@ func textResult(text string) *mcp.CallToolResult {
 }
 ```
 
+Use `jsonResult` when the successful response body should be JSON (e.g. structured data from mutating operations):
+
+```go
+func jsonResult(v any) (*mcp.CallToolResult, error) {
+    data, err := json.Marshal(v)
+    if err != nil {
+        return nil, fmt.Errorf("marshal response: %w", err)
+    }
+    return textResult(string(data)), nil
+}
+```
+
 ### Shared traversal and lookup utilities
 
 `handler.go` also defines helpers for navigating the topic tree. Use them rather than writing new traversal code:
@@ -238,7 +250,7 @@ Also verify that documentation reflects the change before finishing. Update **`A
 | Change made | What to review/update |
 |---|---|
 | New file added or removed | `Project Structure` tree in `AGENTS.md` |
-| New handler helper added to `handler.go` | Traversal/lookup utilities table in `AGENTS.md` |
+| New handler helper added to `handler.go` | Appropriate subsection in `AGENTS.md` (traversal/lookup table for tree helpers; Text response helper for `textResult` / `jsonResult`) |
 | New tool registered | Conventions section in `AGENTS.md` if a new pattern is introduced |
 | New struct field or codec allowlist entry | Schema Critical Notes in `AGENTS.md` |
 | New convention established | `Conventions` section in `AGENTS.md` |

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Multi-platform build (no `--load`; suitable for CI or registry push):
 docker buildx build --platform linux/amd64,linux/arm64 .
 ```
 
-**Linux (amd64 host):** Building the `linux/arm64` variant runs `RUN` steps inside
-an ARM image. Without [QEMU user emulation](https://docs.docker.com/build/building/multi-platform/#qemu),
+**Linux (amd64 host):** Building the `linux/arm64` variant runs `RUN` steps
+inside an ARM image. Without [QEMU user emulation](https://docs.docker.com/build/building/multi-platform/#qemu),
 those steps fail with `exec format error`. Install binfmt handlers once:
 
 ```bash
@@ -199,22 +199,29 @@ Most tools here target a topic and take a `topic_id` from Tier 2 (or from
 prior results). A few use other ids (`from_id`/`to_id`, `relationship_id`,
 etc.)—see each row.
 
-| Tool                              | Description                                                                                                  |
-|-----------------------------------|--------------------------------------------------------------------------------------------------------------|
-| `xmind_add_topic`                 | Add a new child topic under a specified parent.                                                              |
-| `xmind_add_topics_bulk`           | Add multiple topics (flat list or nested subtree) under a parent in one call.                                |
-| `xmind_duplicate_topic`           | Deep-clone a topic subtree under another parent (same sheet); sheet relationships are not copied.            |
-| `xmind_rename_topic`              | Change the title of an existing topic.                                                                       |
-| `xmind_delete_topic`              | Remove a topic and all its descendants.                                                                      |
-| `xmind_move_topic`                | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append).       |
-| `xmind_reorder_children`          | Change the order of a topic's children without reparenting.                                                  |
-| `xmind_set_topic_properties`      | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool. |
-| `xmind_set_topic_properties_bulk` | Apply the same metadata updates as `xmind_set_topic_properties` to many topic IDs in one read/write.         |
-| `xmind_add_floating_topic`        | Add a detached floating topic not connected to the main hierarchy.                                           |
-| `xmind_add_relationship`          | Draw a labeled connector between any two topics.                                                             |
-| `xmind_delete_relationship`       | Remove a relationship by id (from `xmind_list_relationships`).                                               |
-| `xmind_add_summary`               | Add a summary callout bracketing a range of sibling topics.                                                  |
-| `xmind_add_boundary`              | Add a visual boundary enclosure around all children of a topic.                                              |
+On success, **`xmind_add_topic`**, **`xmind_add_topics_bulk`**,
+**`xmind_duplicate_topic`**, and **`xmind_move_topic`** return **JSON** (topic
+ids, insertion indices, sibling counts, and related fields). Exact keys match
+each tool's description from the running MCP server. Other mutation tools in
+this tier return plain-text success messages unless their descriptions say
+otherwise.
+
+| Tool                              | Description                                                                                                                  |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `xmind_add_topic`                 | Add a new child topic under a specified parent; success body is JSON.                                                        |
+| `xmind_add_topics_bulk`           | Add multiple topics (flat list or nested subtree) under a parent in one call; success body is JSON.                          |
+| `xmind_duplicate_topic`           | Deep-clone a topic subtree under another parent (same sheet); sheet relationships are not copied; success body is JSON.      |
+| `xmind_rename_topic`              | Change the title of an existing topic.                                                                                       |
+| `xmind_delete_topic`              | Remove a topic and all its descendants.                                                                                      |
+| `xmind_move_topic`                | Move a topic (and subtree) to a new parent; optional `position` sets insertion order (omit to append); success body is JSON. |
+| `xmind_reorder_children`          | Change the order of a topic's children without reparenting.                                                                  |
+| `xmind_set_topic_properties`      | Set or update topic metadata (notes, labels, markers, link, remove_markers); clearing rules are on the tool.                 |
+| `xmind_set_topic_properties_bulk` | Apply the same metadata updates as `xmind_set_topic_properties` to many topic IDs in one read/write.                         |
+| `xmind_add_floating_topic`        | Add a detached floating topic not connected to the main hierarchy.                                                           |
+| `xmind_add_relationship`          | Draw a labeled connector between any two topics.                                                                             |
+| `xmind_delete_relationship`       | Remove a relationship by id (from `xmind_list_relationships`).                                                               |
+| `xmind_add_summary`               | Add a summary callout bracketing a range of sibling topics.                                                                  |
+| `xmind_add_boundary`              | Add a visual boundary enclosure around all children of a topic.                                                              |
 
 ### Tier 4: Utilities
 

--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -27,6 +27,15 @@ func textResult(text string) *mcp.CallToolResult {
 	}
 }
 
+// jsonResult marshals v to JSON and returns it as the tool result text body.
+func jsonResult(v any) (*mcp.CallToolResult, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal response: %w", err)
+	}
+	return textResult(string(data)), nil
+}
+
 // countTopics returns 1 (self) plus all descendants in attached, detached, and summary.
 func countTopics(t *xmind.Topic) int {
 	if t == nil {

--- a/internal/server/handler/integration_test.go
+++ b/internal/server/handler/integration_test.go
@@ -184,7 +184,7 @@ func TestEdgeCase_UnicodeContent(t *testing.T) {
 	if addRes.IsError {
 		t.Fatal(textContent(t, addRes))
 	}
-	tid := strings.TrimPrefix(textContent(t, addRes), "added topic id ")
+	tid := parseAddTopicResult(t, addRes).ID
 	note := "Note: مرحبا • emoji 🚀"
 	res := callTool(t, h.SetTopicProperties, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -18,6 +18,36 @@ import (
 const maxBulkTopicsDepth = 64
 const maxBulkTopicsTotal = 10000
 
+type addTopicResponse struct {
+	ID           string `json:"id"`
+	Position     int    `json:"position"`
+	SiblingCount int    `json:"siblingCount"`
+}
+
+type addTopicsBulkResponse struct {
+	AddedCount    int      `json:"addedCount"`
+	ParentID      string   `json:"parentId"`
+	FirstPosition int      `json:"firstPosition"`
+	SiblingCount  int      `json:"siblingCount"`
+	RootTopicIDs  []string `json:"rootTopicIds"`
+}
+
+type duplicateTopicResponse struct {
+	SourceID     string `json:"sourceId"`
+	NewRootID    string `json:"newRootId"`
+	ParentID     string `json:"parentId"`
+	CopiedCount  int    `json:"copiedCount"`
+	Position     int    `json:"position"`
+	SiblingCount int    `json:"siblingCount"`
+}
+
+type moveTopicResponse struct {
+	TopicID      string `json:"topicId"`
+	ParentID     string `json:"parentId"`
+	Position     int    `json:"position"`
+	SiblingCount int    `json:"siblingCount"`
+}
+
 // plainToRealHTML converts a plain-text note string to minimal XMind-compatible HTML.
 // XMind's Notes struct requires both plain and realHTML to be populated; writing plain
 // text into realHTML directly causes the rich-text panel to display it unstyled and
@@ -372,7 +402,11 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
-	return textResult(fmt.Sprintf("added topic id %s", topic.ID)), nil
+	return jsonResult(addTopicResponse{
+		ID:           topic.ID,
+		Position:     insertIdx,
+		SiblingCount: len(parent.Children.Attached),
+	})
 }
 
 // DuplicateTopic deep-clones a topic subtree and attaches it as an attached child of target_parent_id.
@@ -443,10 +477,14 @@ func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolReque
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
-	return textResult(fmt.Sprintf(
-		"duplicated topic %s as %s under %s (%d topics copied)",
-		topicID, newRootID, targetParentID, n,
-	)), nil
+	return jsonResult(duplicateTopicResponse{
+		SourceID:     topicID,
+		NewRootID:    newRootID,
+		ParentID:     targetParentID,
+		CopiedCount:  n,
+		Position:     insertIdx,
+		SiblingCount: len(targetParent.Children.Attached),
+	})
 }
 
 // AddTopicsBulk adds a nested tree under parent_id.
@@ -492,12 +530,23 @@ func (h *XMindHandler) AddTopicsBulk(ctx context.Context, req mcp.CallToolReques
 	}
 
 	ch := ensureChildren(parent)
+	prevLen := len(ch.Attached)
 	ch.Attached = append(ch.Attached, topics...)
+	rootIDs := make([]string, len(topics))
+	for i := range topics {
+		rootIDs[i] = topics[i].ID
+	}
 	sh.RevisionID = uuid.New().String()
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
-	return textResult(fmt.Sprintf("added %d topics under parent %s", count, parentID)), nil
+	return jsonResult(addTopicsBulkResponse{
+		AddedCount:    count,
+		ParentID:      parentID,
+		FirstPosition: prevLen,
+		SiblingCount:  len(ch.Attached),
+		RootTopicIDs:  rootIDs,
+	})
 }
 
 // RenameTopic sets a topic title.
@@ -679,7 +728,12 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	n := len(newParent.Children.Attached)
-	return textResult(fmt.Sprintf("moved topic %s to position %d under %s (%d attached children)", topicID, moveInsertIdx, newParentID, n)), nil
+	return jsonResult(moveTopicResponse{
+		TopicID:      topicID,
+		ParentID:     newParentID,
+		Position:     moveInsertIdx,
+		SiblingCount: n,
+	})
 }
 
 // ReorderChildren reorders attached children of parent_id.

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -11,7 +12,45 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mab-go/xmind-mcp/internal/xmind"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
+
+func parseAddTopicResult(t *testing.T, res *mcp.CallToolResult) addTopicResponse {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("expected success, got tool error: %s", textContent(t, res))
+	}
+	var out addTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("parse add topic JSON: %v", err)
+	}
+	return out
+}
+
+func parseAddTopicsBulkResult(t *testing.T, res *mcp.CallToolResult) addTopicsBulkResponse {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("expected success, got tool error: %s", textContent(t, res))
+	}
+	var out addTopicsBulkResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("parse add topics bulk JSON: %v", err)
+	}
+	return out
+}
+
+func parseMoveTopicResult(t *testing.T, res *mcp.CallToolResult) moveTopicResponse {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("expected success, got tool error: %s", textContent(t, res))
+	}
+	var out moveTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("parse move topic JSON: %v", err)
+	}
+	return out
+}
 
 func TestAddTopicAndRevisionID(t *testing.T) {
 	h := NewXMindHandler()
@@ -37,14 +76,13 @@ func TestAddTopicAndRevisionID(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("AddTopic: %s", textContent(t, res))
 	}
-	msg := textContent(t, res)
-	const prefix = "added topic id "
-	if !strings.HasPrefix(msg, prefix) {
-		t.Fatalf("unexpected message: %q", msg)
-	}
-	newID := strings.TrimPrefix(msg, prefix)
+	added := parseAddTopicResult(t, res)
+	newID := added.ID
 	if _, err := uuid.Parse(newID); err != nil {
 		t.Fatalf("new topic id is not a valid UUID: %q", newID)
+	}
+	if added.Position != 0 || added.SiblingCount != 1 {
+		t.Fatalf("unexpected add topic response: %+v", added)
 	}
 
 	sheets, err = xmind.ReadMap(path)
@@ -159,8 +197,12 @@ func TestAddTopicsBulkNested(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("AddTopicsBulk: %s", textContent(t, res))
 	}
-	if !strings.Contains(textContent(t, res), "added 3 topics") {
-		t.Fatalf("unexpected message: %s", textContent(t, res))
+	bulk := parseAddTopicsBulkResult(t, res)
+	if bulk.AddedCount != 3 || len(bulk.RootTopicIDs) != 1 || bulk.FirstPosition != 0 || bulk.SiblingCount != 1 {
+		t.Fatalf("unexpected bulk response: %+v", bulk)
+	}
+	if bulk.ParentID != rootID {
+		t.Fatalf("unexpected parentId: got %q want %q", bulk.ParentID, rootID)
 	}
 
 	sheets, err = xmind.ReadMap(path)
@@ -172,6 +214,9 @@ func TestAddTopicsBulkNested(t *testing.T) {
 		t.Fatal("expected one top-level branch")
 	}
 	l1 := &rt.Children.Attached[0]
+	if bulk.RootTopicIDs[0] != l1.ID {
+		t.Fatalf("rootTopicIds[0] %q != L1 id %q", bulk.RootTopicIDs[0], l1.ID)
+	}
 	if l1.Title != "L1" || l1.Children == nil || len(l1.Children.Attached) != 1 {
 		t.Fatalf("L1: %+v", l1)
 	}
@@ -195,7 +240,7 @@ func TestRenameTopic(t *testing.T) {
 	addRes := callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sheets[0].ID, "parent_id": rootID, "title": "Old",
 	})
-	tid := strings.TrimPrefix(textContent(t, addRes), "added topic id ")
+	tid := parseAddTopicResult(t, addRes).ID
 
 	res := callTool(t, h.RenameTopic, map[string]any{
 		"path": path, "sheet_id": sheets[0].ID, "topic_id": tid, "title": "New",
@@ -234,7 +279,7 @@ func TestDeleteTopic(t *testing.T) {
 	addRes := callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sheets[0].ID, "parent_id": rootID, "title": "X",
 	})
-	tid := strings.TrimPrefix(textContent(t, addRes), "added topic id ")
+	tid := parseAddTopicResult(t, addRes).ID
 
 	res := callTool(t, h.DeleteTopic, map[string]any{
 		"path": path, "sheet_id": sheets[0].ID, "topic_id": tid,
@@ -259,12 +304,12 @@ func TestMoveTopicCycleError(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rootID := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "A",
-	})), "added topic id ")
-	bID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	bID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": aID, "title": "B",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.MoveTopic, map[string]any{
 		"path":          path,
@@ -285,12 +330,12 @@ func TestMoveTopic(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rootID := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "A",
-	})), "added topic id ")
-	bID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	bID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "B",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.MoveTopic, map[string]any{
 		"path":          path,
@@ -300,6 +345,10 @@ func TestMoveTopic(t *testing.T) {
 	})
 	if res.IsError {
 		t.Fatal(textContent(t, res))
+	}
+	mv := parseMoveTopicResult(t, res)
+	if mv.TopicID != bID || mv.ParentID != aID || mv.Position != 0 || mv.SiblingCount != 1 {
+		t.Fatalf("unexpected move response: %+v", mv)
 	}
 	sheets, _ = xmind.ReadMap(path)
 	root := &sheets[0].RootTopic
@@ -329,12 +378,12 @@ func TestMoveTopicSiblingForward(t *testing.T) {
 	rid := sheets[0].RootTopic.ID
 
 	// Add Alpha then Gamma so Alpha is at index 0, Gamma at index 1.
-	alphaID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	alphaID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Alpha",
-	})), "added topic id ")
-	gammaID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	gammaID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Gamma",
-	})), "added topic id ")
+	})).ID
 
 	// Move Alpha (index 0) under Gamma (index 1) — destination is AFTER source.
 	res := callTool(t, h.MoveTopic, map[string]any{
@@ -345,6 +394,10 @@ func TestMoveTopicSiblingForward(t *testing.T) {
 	})
 	if res.IsError {
 		t.Fatalf("MoveTopic: %s", textContent(t, res))
+	}
+	mv := parseMoveTopicResult(t, res)
+	if mv.TopicID != alphaID || mv.ParentID != gammaID || mv.Position != 0 || mv.SiblingCount != 1 {
+		t.Fatalf("unexpected move response: %+v", mv)
 	}
 
 	sheets, _ = xmind.ReadMap(path)
@@ -389,12 +442,12 @@ func TestMoveTopicSiblingBackward(t *testing.T) {
 	rid := sheets[0].RootTopic.ID
 
 	// Add Gamma then Alpha so Gamma is at index 0, Alpha at index 1.
-	gammaID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	gammaID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Gamma",
-	})), "added topic id ")
-	alphaID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	alphaID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Alpha",
-	})), "added topic id ")
+	})).ID
 
 	// Move Alpha (index 1) under Gamma (index 0) — destination is BEFORE source.
 	res := callTool(t, h.MoveTopic, map[string]any{
@@ -405,6 +458,10 @@ func TestMoveTopicSiblingBackward(t *testing.T) {
 	})
 	if res.IsError {
 		t.Fatalf("MoveTopic: %s", textContent(t, res))
+	}
+	mv := parseMoveTopicResult(t, res)
+	if mv.TopicID != alphaID || mv.ParentID != gammaID || mv.Position != 0 || mv.SiblingCount != 1 {
+		t.Fatalf("unexpected move response: %+v", mv)
 	}
 
 	sheets, _ = xmind.ReadMap(path)
@@ -462,12 +519,12 @@ func TestReorderChildren(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rootID := sheets[0].RootTopic.ID
-	idA := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	idA := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "A",
-	})), "added topic id ")
-	idB := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	idB := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "B",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.ReorderChildren, map[string]any{
 		"path":        path,
@@ -576,7 +633,7 @@ func TestDeleteTopicBumpsRevisionID(t *testing.T) {
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
 	addRes := callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": "X"})
-	tid := strings.TrimPrefix(textContent(t, addRes), "added topic id ")
+	tid := parseAddTopicResult(t, addRes).ID
 	res := callTool(t, h.DeleteTopic, map[string]any{"path": path, "sheet_id": sid, "topic_id": tid})
 	if res.IsError {
 		t.Fatal(textContent(t, res))
@@ -930,12 +987,12 @@ func TestAddRelationship(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
-	})), "added topic id ")
-	bID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	bID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "B",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.AddRelationship, map[string]any{
 		"path": path, "sheet_id": sid, "from_id": aID, "to_id": bID, "label": "relates",
@@ -962,12 +1019,12 @@ func TestDeleteRelationship(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
-	})), "added topic id ")
-	bID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	bID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "B",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.AddRelationship, map[string]any{
 		"path": path, "sheet_id": sid, "from_id": aID, "to_id": bID,
@@ -1037,9 +1094,9 @@ func TestAddRelationshipInvalidTopic(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.AddRelationship, map[string]any{
 		"path": path, "sheet_id": sid, "from_id": aID, "to_id": "00000000-0000-0000-0000-000000000000",
@@ -1064,12 +1121,12 @@ func TestAddRelationshipLabelWrongType(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
-	})), "added topic id ")
-	bID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	bID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "B",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.AddRelationship, map[string]any{
 		"path": path, "sheet_id": sid, "from_id": aID, "to_id": bID, "label": float64(42),
@@ -1256,7 +1313,7 @@ func TestRenameTopicClearsTitleUnedited(t *testing.T) {
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
 	addRes := callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": "Child"})
-	tid := strings.TrimPrefix(textContent(t, addRes), "added topic id ")
+	tid := parseAddTopicResult(t, addRes).ID
 	sheets, err = xmind.ReadMap(path)
 	if err != nil {
 		t.Fatal(err)
@@ -1291,17 +1348,21 @@ func TestMoveTopicToPosition(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	_ = strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	_ = parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
-	})), "added topic id ")
-	idB := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	idB := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "B",
-	})), "added topic id ")
+	})).ID
 	res := callTool(t, h.MoveTopic, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": idB, "new_parent_id": rid, "position": float64(0),
 	})
 	if res.IsError {
 		t.Fatal(textContent(t, res))
+	}
+	mv := parseMoveTopicResult(t, res)
+	if mv.TopicID != idB || mv.ParentID != rid || mv.Position != 0 || mv.SiblingCount != 2 {
+		t.Fatalf("unexpected move response: %+v", mv)
 	}
 	sheets, _ = xmind.ReadMap(path)
 	ch := sheets[0].RootTopic.Children.Attached
@@ -1318,15 +1379,15 @@ func TestDeleteTopicAlsoRemovesDescendants(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	l1 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	l1 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "L1",
-	})), "added topic id ")
-	l2 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	l2 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": l1, "title": "L2",
-	})), "added topic id ")
-	l3 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	l3 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": l2, "title": "L3",
-	})), "added topic id ")
+	})).ID
 	res := callTool(t, h.DeleteTopic, map[string]any{"path": path, "sheet_id": sid, "topic_id": l1})
 	if res.IsError {
 		t.Fatal(textContent(t, res))
@@ -1428,12 +1489,12 @@ func TestSetTopicPropertiesBulkHappyPath(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	id1 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	id1 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "One",
-	})), "added topic id ")
-	id2 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	id2 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Two",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
 		"path":      path,
@@ -1468,12 +1529,12 @@ func TestSetTopicPropertiesBulkMarkersAndRemoveMarkers(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	id1 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	id1 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "One",
-	})), "added topic id ")
-	id2 := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	})).ID
+	id2 := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Two",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.SetTopicPropertiesBulk, map[string]any{
 		"path":      path,
@@ -1735,9 +1796,9 @@ func TestDuplicateTopicHappyPath(t *testing.T) {
 	}
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	mid := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	mid := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Mid",
-	})), "added topic id ")
+	})).ID
 	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": mid, "title": "Leaf"})
 	res := callTool(t, h.DuplicateTopic, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": mid, "target_parent_id": rid,
@@ -1745,13 +1806,17 @@ func TestDuplicateTopicHappyPath(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("DuplicateTopic: %s", textContent(t, res))
 	}
-	msg := textContent(t, res)
-	var oldID, newID, parentID string
-	var n int
-	_, scanErr := fmt.Sscanf(msg, "duplicated topic %s as %s under %s (%d topics copied)", &oldID, &newID, &parentID, &n)
-	if scanErr != nil || oldID != mid || parentID != rid || n != 2 {
-		t.Fatalf("unexpected message: %q (scanErr=%v)", msg, scanErr)
+	var dup duplicateTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &dup); err != nil {
+		t.Fatalf("parse duplicate topic JSON: %v", err)
 	}
+	if dup.SourceID != mid || dup.ParentID != rid || dup.CopiedCount != 2 {
+		t.Fatalf("unexpected duplicate response: %+v", dup)
+	}
+	if dup.Position != 1 || dup.SiblingCount != 2 {
+		t.Fatalf("unexpected duplicate response position/siblingCount: %+v", dup)
+	}
+	newID := dup.NewRootID
 	if newID == mid {
 		t.Fatalf("expected new root id to differ from source: %s", newID)
 	}
@@ -1788,9 +1853,9 @@ func TestDuplicateTopicPositionInsertAtZeroAndAppend(t *testing.T) {
 	rid := sheets[0].RootTopic.ID
 	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": "A"})
 	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": "B"})
-	src := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	src := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Src",
-	})), "added topic id ")
+	})).ID
 	callTool(t, h.DuplicateTopic, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": src, "target_parent_id": rid, "position": float64(0),
 	})
@@ -1828,9 +1893,9 @@ func TestDuplicateTopicErrors(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	child := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	child := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "C",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.DuplicateTopic, map[string]any{
 		"path": path, "sheet_id": "00000000-0000-0000-0000-000000000099", "topic_id": child, "target_parent_id": rid,

--- a/internal/server/handler/utils_test.go
+++ b/internal/server/handler/utils_test.go
@@ -65,9 +65,9 @@ func TestFlattenToOutlineSubtree(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	aID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
-	})), "added topic id ")
+	})).ID
 	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": aID, "title": "Leaf"})
 
 	res := callTool(t, h.FlattenToOutline, map[string]any{
@@ -330,9 +330,9 @@ func TestFlattenImportRoundTripMarkdownUnderParent(t *testing.T) {
 	sheets, _ := xmind.ReadMap(path)
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	hubID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	hubID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path, "sheet_id": sid, "parent_id": rid, "title": "Hub",
-	})), "added topic id ")
+	})).ID
 	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": hubID, "title": "Branch A"})
 	callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": hubID, "title": "Branch B"})
 
@@ -345,9 +345,9 @@ func TestFlattenImportRoundTripMarkdownUnderParent(t *testing.T) {
 	sheets2, _ := xmind.ReadMap(path2)
 	sid2 := sheets2[0].ID
 	rid2 := sheets2[0].RootTopic.ID
-	hub2ID := strings.TrimPrefix(textContent(t, callTool(t, h.AddTopic, map[string]any{
+	hub2ID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
 		"path": path2, "sheet_id": sid2, "parent_id": rid2, "title": "Hub2",
-	})), "added topic id ")
+	})).ID
 
 	res := callTool(t, h.ImportFromOutline, map[string]any{
 		"path": path2, "sheet_id": sid2, "parent_id": hub2ID, "outline": flat1,

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -101,7 +101,7 @@ var toolFindTopic = mcp.NewTool(
 
 var toolAddTopic = mcp.NewTool(
 	"xmind_add_topic",
-	mcp.WithDescription("Add a new attached child topic under a parent topic."),
+	mcp.WithDescription("Add a new attached child topic under a parent topic. Returns JSON: {\"id\":\"…\",\"position\":N,\"siblingCount\":N}."),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("parent_id", mcp.Required(), mcp.Description("ID of the parent topic")),
@@ -111,7 +111,7 @@ var toolAddTopic = mcp.NewTool(
 
 var toolAddTopicsBulk = mcp.NewTool(
 	"xmind_add_topics_bulk",
-	mcp.WithDescription("Add multiple topics under a parent in one call; each item may nest children."),
+	mcp.WithDescription("Add multiple topics under a parent in one call; each item may nest children. Returns JSON: {\"addedCount\":N,\"parentId\":\"…\",\"firstPosition\":N,\"siblingCount\":N,\"rootTopicIds\":[\"…\"]}."),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("parent_id", mcp.Required(), mcp.Description("ID of the parent topic")),
@@ -122,7 +122,8 @@ var toolDuplicateTopic = mcp.NewTool(
 	"xmind_duplicate_topic",
 	mcp.WithDescription(
 		"Deep-clone a topic and its subtree (same sheet only) and attach the copy as an attached child of target_parent_id. "+
-			"Sheet-level relationships are not copied. Hyperlinks or note text that reference other topic IDs by ID are not rewritten and may still point at the original topics.",
+			"Sheet-level relationships are not copied. Hyperlinks or note text that reference other topic IDs by ID are not rewritten and may still point at the original topics. "+
+			`Returns JSON: {"sourceId":"…","newRootId":"…","parentId":"…","copiedCount":N,"position":N,"siblingCount":N}.`,
 	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Sheet containing the source topic")),
@@ -150,7 +151,7 @@ var toolDeleteTopic = mcp.NewTool(
 
 var toolMoveTopic = mcp.NewTool(
 	"xmind_move_topic",
-	mcp.WithDescription("Move a topic (and subtree) to a new parent as an attached child. Use position to control insertion order; omit to append at the end."),
+	mcp.WithDescription("Move a topic (and subtree) to a new parent as an attached child. Use position to control insertion order; omit to append at the end. Returns JSON: {\"topicId\":\"…\",\"parentId\":\"…\",\"position\":N,\"siblingCount\":N}."),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("topic_id", mcp.Required(), mcp.Description("ID of the topic to move")),


### PR DESCRIPTION
Plain-text confirmations forced extra read calls to learn placement and sibling counts. This commit returns JSON for add, bulk add, duplicate, and move so clients get ids, positions, and counts immediately.

AddTopicsBulk also includes firstPosition (index of the first inserted root). MoveTopic is included here for consistency with the same pattern, though issue #20 scoped it as a possible follow-up.

- Add jsonResult helper and response structs; wire mutate handlers
- Document JSON responses in AGENTS.md, README, and tool descriptions
- Update integration and unit tests to parse and assert JSON bodies

Closes #20