### PR TITLE
Add ancestryPath to xmind_find_topic and xmind_search_topics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ func jsonResult(v any) (*mcp.CallToolResult, error) {
 |---|---|
 | `walkTopics(root, depth, parent, fn)` | Preorder DFS over attached → detached → summary; `fn` returns `false` to stop |
 | `findTopicByID(root, id)` | First topic matching `id` in DFS order |
+| `ancestryPath(root, targetID)` | Titles from root to (not including) the target; `nil` if target is root or not found |
 | `findParentOfTopic(root, targetID)` | Parent topic, child index, and list name (`"attached"`, `"detached"`, `"summary"`) |
 | `isDescendantOf(ancestor, descendantID)` | Reports whether a node is the ancestor or any node in its subtree |
 | `countTopics(t)` | Total node count for a subtree (self + all descendants) |

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ of the tree. Some write tools instead need sheet-level ids or ids from
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `xmind_get_subtree`          | Return the full topic hierarchy rooted at a given topic (or the whole sheet).                                                             |
 | `xmind_get_topic_properties` | Return one topic's metadata as JSON (notes, markers, boundaries, sheet relationships for that topic, child counts); use to verify writes. |
-| `xmind_search_topics`        | Search for topics by keyword; returns matching topics with their IDs and context.                                                         |
-| `xmind_find_topic`           | Find a single topic by exact title; returns its ID and immediate context.                                                                 |
+| `xmind_search_topics`        | Search for topics by keyword; returns matches with IDs, ancestryPath (titles from sheet root to parent of match, or null at sheet root), parent title, depth, and sheet fields when searching all sheets. |
+| `xmind_find_topic`           | Find a single topic by exact title; returns ID, ancestryPath (sheet-root chain to parent of match; null at sheet root; not relative to parent_id scope), plus parent/sibling context relative to the search scope. |
 
 ### Tier 3: Topic Mutations
 

--- a/internal/server/handler/find.go
+++ b/internal/server/handler/find.go
@@ -218,12 +218,13 @@ type searchTopicsResponse struct {
 }
 
 type searchTopicItem struct {
-	SheetID     string `json:"sheetId,omitempty"`
-	SheetTitle  string `json:"sheetTitle,omitempty"`
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	ParentTitle string `json:"parentTitle"`
-	Depth       int    `json:"depth"`
+	SheetID      string   `json:"sheetId,omitempty"`
+	SheetTitle   string   `json:"sheetTitle,omitempty"`
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	AncestryPath []string `json:"ancestryPath"`
+	ParentTitle  string   `json:"parentTitle"`
+	Depth        int      `json:"depth"`
 }
 
 // SearchTopics finds topics whose title contains the query (case-insensitive).
@@ -285,10 +286,11 @@ func (h *XMindHandler) SearchTopics(ctx context.Context, req mcp.CallToolRequest
 					pt = parent.Title
 				}
 				item := searchTopicItem{
-					ID:          t.ID,
-					Title:       t.Title,
-					ParentTitle: pt,
-					Depth:       depth,
+					ID:           t.ID,
+					Title:        t.Title,
+					AncestryPath: ancestryPath(&sh.RootTopic, t.ID),
+					ParentTitle:  pt,
+					Depth:        depth,
 				}
 				if allSheets {
 					item.SheetID = sh.ID
@@ -315,6 +317,7 @@ func (h *XMindHandler) SearchTopics(ctx context.Context, req mcp.CallToolRequest
 type findTopicResponse struct {
 	ID             string   `json:"id"`
 	Title          string   `json:"title"`
+	AncestryPath   []string `json:"ancestryPath"`
 	ParentTitle    string   `json:"parentTitle"`
 	SiblingTitles  []string `json:"siblingTitles"`
 	ChildrenTitles []string `json:"childrenTitles"`
@@ -442,8 +445,9 @@ func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (
 	}
 
 	resp := findTopicResponse{
-		ID:    found.ID,
-		Title: found.Title,
+		ID:           found.ID,
+		Title:        found.Title,
+		AncestryPath: ancestryPath(&sh.RootTopic, found.ID),
 	}
 	if foundParent != nil {
 		resp.ParentTitle = foundParent.Title

--- a/internal/server/handler/find_test.go
+++ b/internal/server/handler/find_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -13,6 +14,9 @@ const kitchenSinkAlphaTopicID = "169d72af-6345-47ad-90b0-5b587f1f9619"
 
 // Parent of "Alpha" on Sheet 1 - Mind Map.
 const kitchenSinkSubtopic1TopicID = "61cc4754-20ec-4479-9e58-f7eaa985520a"
+
+// Ancestry path from sheet root to parent of "Alpha" on Sheet 1 - Mind Map.
+var kitchenSinkAlphaAncestryPath = []string{"Central Topic", "Main Topic 1", "Subtopic 1"}
 
 const kitchenSinkSheet10Title = "Sheet 10 - Topic Properties"
 
@@ -132,6 +136,63 @@ func TestFindTopicKitchenSink(t *testing.T) {
 	if out.ID != kitchenSinkAlphaTopicID {
 		t.Fatalf("id: got %q want %q", out.ID, kitchenSinkAlphaTopicID)
 	}
+	if !slices.Equal(out.AncestryPath, kitchenSinkAlphaAncestryPath) {
+		t.Fatalf("ancestryPath: got %#v want %#v", out.AncestryPath, kitchenSinkAlphaAncestryPath)
+	}
+	if out.ParentTitle != kitchenSinkAlphaAncestryPath[len(kitchenSinkAlphaAncestryPath)-1] {
+		t.Fatalf("parentTitle should equal last ancestry segment: got %q", out.ParentTitle)
+	}
+}
+
+func TestFindTopicAncestryPathScopedStillAbsolute(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":      kitchenSinkPath(t),
+		"sheet_id":  sheetID,
+		"title":     "Alpha",
+		"parent_id": kitchenSinkSubtopic1TopicID,
+	})
+	if res.IsError {
+		t.Fatalf("FindTopic: %s", textContent(t, res))
+	}
+	var out findTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !slices.Equal(out.AncestryPath, kitchenSinkAlphaAncestryPath) {
+		t.Fatalf("scoped search must still return sheet-root ancestry: got %#v want %#v", out.AncestryPath, kitchenSinkAlphaAncestryPath)
+	}
+}
+
+func TestSearchTopicsAncestryPath(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.SearchTopics, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sheetID,
+		"query":    "alpha",
+	})
+	if res.IsError {
+		t.Fatalf("SearchTopics: %s", textContent(t, res))
+	}
+	var out searchTopicsResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var alpha *searchTopicItem
+	for i := range out.Matches {
+		if out.Matches[i].Title == "Alpha" {
+			alpha = &out.Matches[i]
+			break
+		}
+	}
+	if alpha == nil {
+		t.Fatalf("no Alpha in matches")
+	}
+	if !slices.Equal(alpha.AncestryPath, kitchenSinkAlphaAncestryPath) {
+		t.Fatalf("ancestryPath: got %#v want %#v", alpha.AncestryPath, kitchenSinkAlphaAncestryPath)
+	}
 }
 
 func TestGetSubtreeWithTopicID(t *testing.T) {
@@ -247,6 +308,9 @@ func TestSearchTopicsResponseShape(t *testing.T) {
 	}
 	if alpha.ParentTitle != "Subtopic 1" {
 		t.Fatalf("parentTitle: got %q want Subtopic 1", alpha.ParentTitle)
+	}
+	if !slices.Equal(alpha.AncestryPath, kitchenSinkAlphaAncestryPath) {
+		t.Fatalf("ancestryPath: got %#v want %#v", alpha.AncestryPath, kitchenSinkAlphaAncestryPath)
 	}
 	if alpha.Depth != 3 {
 		t.Fatalf("depth: got %d want 3", alpha.Depth)
@@ -525,8 +589,31 @@ func TestFindTopicParentIDSelfMatch(t *testing.T) {
 	if out.ParentTitle != "" {
 		t.Fatalf("parentTitle: got %q want empty (scope root matched)", out.ParentTitle)
 	}
+	if !slices.Equal(out.AncestryPath, kitchenSinkAlphaAncestryPath) {
+		t.Fatalf("ancestryPath must stay sheet-root-relative when scope root matches: got %#v want %#v", out.AncestryPath, kitchenSinkAlphaAncestryPath)
+	}
 	if len(out.SiblingTitles) != 0 {
 		t.Fatalf("expected no siblingTitles when scope root matches, got %#v", out.SiblingTitles)
+	}
+}
+
+func TestFindTopicSheetRootAncestryNil(t *testing.T) {
+	h := NewXMindHandler()
+	sheetID := firstKitchenSinkSheetID(t)
+	res := callTool(t, h.FindTopic, map[string]any{
+		"path":     kitchenSinkPath(t),
+		"sheet_id": sheetID,
+		"title":    "Central Topic",
+	})
+	if res.IsError {
+		t.Fatalf("FindTopic: %s", textContent(t, res))
+	}
+	var out findTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.AncestryPath != nil {
+		t.Fatalf("sheet root match: want nil ancestryPath, got %#v", out.AncestryPath)
 	}
 }
 

--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -134,6 +134,47 @@ func findTopicByID(root *xmind.Topic, id string) *xmind.Topic {
 	return found
 }
 
+// ancestryPath returns titles from root down to (but not including) the target topic.
+// Returns nil if targetID is the root itself or not found.
+// NOTE: does a full DFS per call; fine for typical map sizes (<1000 topics).
+// If performance becomes a concern, build a parent-ID map in one pass instead.
+func ancestryPath(root *xmind.Topic, targetID string) []string {
+	var path []string
+	if buildAncestryPath(root, targetID, &path) {
+		return path
+	}
+	return nil
+}
+
+func buildAncestryPath(current *xmind.Topic, targetID string, path *[]string) bool {
+	if current == nil {
+		return false
+	}
+	if current.ID == targetID {
+		return true
+	}
+	*path = append(*path, current.Title)
+	if current.Children != nil {
+		for i := range current.Children.Attached {
+			if buildAncestryPath(&current.Children.Attached[i], targetID, path) {
+				return true
+			}
+		}
+		for i := range current.Children.Detached {
+			if buildAncestryPath(&current.Children.Detached[i], targetID, path) {
+				return true
+			}
+		}
+		for i := range current.Children.Summary {
+			if buildAncestryPath(&current.Children.Summary[i], targetID, path) {
+				return true
+			}
+		}
+	}
+	*path = (*path)[:len(*path)-1]
+	return false
+}
+
 // walkTopics visits topic in preorder depth-first: attached, then detached, then summary.
 // fn returns false to stop the walk entirely. walkTopics returns false if the walk was stopped early.
 func walkTopics(topic *xmind.Topic, depth int, parent *xmind.Topic, fn func(t *xmind.Topic, depth int, parent *xmind.Topic) bool) bool {

--- a/internal/server/handler/handler_test.go
+++ b/internal/server/handler/handler_test.go
@@ -49,3 +49,32 @@ func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
 		t.Fatalf("summary range should be preserved, got %q", clone.Summaries[0].Range)
 	}
 }
+
+func TestAncestryPathHelper(t *testing.T) {
+	root := &xmind.Topic{ID: "r", Title: "Root"}
+	if p := ancestryPath(root, root.ID); p != nil {
+		t.Fatalf("root target: want nil, got %#v", p)
+	}
+	if p := ancestryPath(root, "no-such-id"); p != nil {
+		t.Fatalf("missing id: want nil, got %#v", p)
+	}
+
+	child := &xmind.Topic{ID: "c", Title: "Child"}
+	root.Children = &xmind.Children{Attached: []xmind.Topic{*child}}
+	if got := ancestryPath(root, "c"); len(got) != 1 || got[0] != "Root" {
+		t.Fatalf("direct child: got %#v", got)
+	}
+
+	deep := &xmind.Topic{ID: "d", Title: "Deep"}
+	root.Children.Attached[0].Children = &xmind.Children{Attached: []xmind.Topic{*deep}}
+	if got := ancestryPath(root, "d"); len(got) != 2 || got[0] != "Root" || got[1] != "Child" {
+		t.Fatalf("deeper node: got %#v", got)
+	}
+
+	// Detached branch: second list after attached
+	det := &xmind.Topic{ID: "det", Title: "Float"}
+	root.Children.Detached = []xmind.Topic{*det}
+	if got := ancestryPath(root, "det"); len(got) != 1 || got[0] != "Root" {
+		t.Fatalf("detached child: got %#v", got)
+	}
+}

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -73,7 +73,8 @@ var toolSearchTopics = mcp.NewTool(
 	"xmind_search_topics",
 	mcp.WithDescription(
 		"Search topics by keyword (case-insensitive substring). "+
-			"Omit sheet_id to search all sheets; results will include sheetId and sheetTitle fields.",
+			"Omit sheet_id to search all sheets; results will include sheetId and sheetTitle fields. "+
+			"Each match includes ancestryPath: titles from the sheet root down to (but not including) the matched topic, or null when the match is the sheet root.",
 	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Description("Sheet to search; omit or null to search all sheets")),
@@ -88,6 +89,7 @@ var toolFindTopic = mcp.NewTool(
 			"it is not the structural parent used by xmind_add_topic and other write tools. "+
 			"Omit parent_id or null for the whole sheet. The scope root is visited first, so it can match if its title equals the search title; "+
 			"parentTitle and siblingTitles are relative to that walk, so they are empty when the match is the scope root. "+
+			"ancestryPath lists titles from the sheet root down to (but not including) the matched topic; it is always sheet-root-relative, not relative to parent_id scope, and is null when the match is the sheet root. "+
 			"Use xmind_search_topics for substring or cross-sheet search.",
 	),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),


### PR DESCRIPTION
Both tools previously returned only `parentTitle` for each match, giving AI clients no way to distinguish duplicate topic titles without a follow-up read call. Adding `ancestryPath` (titles from the sheet root down to, but not including, the matched topic) resolves the ambiguity at a glance.

Changes:
- Add `ancestryPath` and `buildAncestryPath` helpers to `handler.go` (DFS with backtracking; nil when target is root or not found)
- Add `AncestryPath []string` to `findTopicResponse` in `find.go`; always computed from the sheet root, never relative to `parent_id`
- Add `AncestryPath []string` to `searchTopicItem` in `find.go`; computed per match from the sheet root
- Extend tool descriptions in `tools.go` to document the field
- Update `README.md` tool table entries for both tools
- Add `ancestryPath` entry to traversal/lookup utilities table in `AGENTS.md`
- Add tests: `TestAncestryPathHelper`, `TestFindTopicAncestryPath- ScopedStillAbsolute`, `TestSearchTopicsAncestryPath`, `TestFindTopicSheetRootAncestryNil`, and extend existing tests to assert the new field

Closes #22