### PR TITLE
Add cyclomatic-complexity reporting via gocyclo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,19 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.3
+
+  cyclomatic-complexity:
+    name: cyclomatic-complexity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Generate gocyclo report (non-blocking)
+        run: make setup && ( make cyclo 2>&1 | tee cyclo.txt; exit 0 )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cyclomatic-complexity
+          path: cyclo.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Dockerfile                — multi-stage image (Alpine build, distroless runtim
 .dockerignore             — Docker build context exclusions
 .github/
   workflows/
-    ci.yml                — test and lint on push and PR
+    ci.yml                — test, lint, and cyclomatic-complexity report artifact on push and PR
     docker-publish.yml    — multi-platform image build and push to GHCR
 cmd/
   xmind-mcp/
@@ -245,6 +245,8 @@ For zip and JSON handling, use Go stdlib only: `archive/zip` and `encoding/json`
 ### Verification before you finish
 
 Treat a change as incomplete until **`make build test lint`** passes locally. The Makefile runs **golangci-lint** (including **revive**); do not rely on `go test` alone to catch style and API-surface rules.
+
+**Cyclomatic complexity (report-only):** After `make setup`, **`make cyclo`** runs [gocyclo](https://github.com/fzipp/gocyclo) with **`-over 10`** on the module tree (`gocyclo` takes a directory path, not a Go package pattern—see the Makefile). It lists functions with complexity **strictly greater than 10** (including `*_test.go`). This is a stricter bar than [Go Report Card](https://goreportcard.com/)’s public check (**cyclo-over=15**); the badge’s **percentage is file-based** (any over-threshold function fails the file), while the CLI lists **individual functions**, so do not expect the same headline number. CI uploads a **`cyclo.txt`** artifact from a **non-blocking** job; it does not fail the workflow when violations exist.
 
 Also verify that documentation reflects the change before finishing. Update **`AGENTS.md`**, **`.cursor/rules/`**, and **`.cursor/skills/`** as needed:
 

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,14 @@ MODULE      := github.com/mab-go/xmind-mcp
 VERSION_PKG := $(MODULE)/internal/version
 GOLANGCI    := $(BIN)/golangci-lint
 GOIMPORTS   := $(BIN)/goimports
+GOCYCLO     := $(BIN)/gocyclo
 # Pinned golangci-lint release for reproducible `make lint`; bump if unsupported on current Go (see go.mod).
 # v2.6.x binaries were built with Go 1.25 and reject go.mod go 1.26+; use v2.9+ for Go 1.26 toolchains.
 GOLANGCI_LINT_VERSION ?= v2.11.3
 # Pinned goimports (golang.org/x/tools); bump if `make fmt` fails or is incompatible with go.mod Go version.
 GOIMPORTS_VERSION ?= v0.38.0
+# Pinned gocyclo (github.com/fzipp/gocyclo); bump for `make cyclo` reproducibility.
+GOCYCLO_VERSION ?= v0.6.0
 
 # golangci-lint must be built with Go >= go.mod; auto follows deps' older go version, so pin to module Go.
 GO_MOD_VERSION := $(shell grep -E '^go ' go.mod | head -1 | awk '{print $$2}')
@@ -33,7 +36,7 @@ OPEN ?= $(shell command -v xdg-open 2>/dev/null || echo "open")
         setup \
         build install run gen-example \
         test test\:cover \
-        lint lint\:fix fmt vet \
+        lint lint\:fix fmt vet cyclo \
         mod\:tidy mod\:verify \
         clean clean\:cache clean\:all \
         versions
@@ -72,12 +75,13 @@ help: ## Show available commands
 # Setup
 #------------------------------------------------------------------------------
 
-setup: ## Install golangci-lint and goimports into ./bin (project-local)
+setup: ## Install required Go tools into ./bin (project-local)
 	@mkdir -p $(BIN)
 	GOTOOLCHAIN=$(TOOLCHAIN_FOR_TOOLS) GOBIN=$(abspath $(BIN)) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	GOTOOLCHAIN=$(TOOLCHAIN_FOR_TOOLS) GOBIN=$(abspath $(BIN)) go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+	GOTOOLCHAIN=$(TOOLCHAIN_FOR_TOOLS) GOBIN=$(abspath $(BIN)) go install github.com/fzipp/gocyclo/cmd/gocyclo@$(GOCYCLO_VERSION)
 	@echo ""
-	@echo "Setup complete: $(GOLANGCI), $(GOIMPORTS)"
+	@echo "Setup complete: $(GOLANGCI), $(GOIMPORTS), $(GOCYCLO)"
 	@echo ""
 
 #------------------------------------------------------------------------------
@@ -88,7 +92,7 @@ build: ## Build binary to ./bin/xmind-mcp with version ldflags
 	@mkdir -p $(BIN)
 	go build -o $(BINARY) -ldflags "$(LDFLAGS)" ./cmd/xmind-mcp
 
-install: ## Run go install with same ldflags (installs to GOPATH/bin or GOBIN)
+install: ## Run go install with same ldflags as 'build' target
 	go install -ldflags "$(LDFLAGS)" ./cmd/xmind-mcp
 
 #------------------------------------------------------------------------------
@@ -99,7 +103,7 @@ run: ## Run via go run (optional: ARGS="--flags")
 	go run -ldflags "$(LDFLAGS)" ./cmd/xmind-mcp $(ARGS)
 
 OUT ?= docs/example.xmind
-gen-example: ## Generate example mind map to docs/example.xmind (override: OUT=path/to/file.xmind)
+gen-example: ## Write example mind map to docs/example.xmind (override: OUT=...)
 	go run ./cmd/gen-example $(OUT)
 
 #------------------------------------------------------------------------------
@@ -126,12 +130,16 @@ lint\:fix: ## Run golangci-lint with --fix
 	@test -x $(GOLANGCI) || (echo "Run 'make setup' to install golangci-lint" && exit 1)
 	$(GOLANGCI) run --fix ./...
 
-fmt: ## Format with goimports (gofmt + import fixes; -l lists changed files, -w writes)
+fmt: ## Format with goimports (gofmt + import fixes)
 	@test -x $(GOIMPORTS) || (echo "Run 'make setup' to install goimports into ./bin" && exit 1)
 	$(GOIMPORTS) -l -w .
 
 vet: ## Run go vet
 	go vet ./...
+
+cyclo: ## Run gocyclo; run 'make setup' first
+	@test -x $(GOCYCLO) || (echo "Run 'make setup' to install gocyclo" && exit 1)
+	$(GOCYCLO) -over 10 .
 
 #------------------------------------------------------------------------------
 # Module
@@ -153,14 +161,15 @@ clean: ## Remove built binary and coverage artifacts
 clean\:cache: ## Clear Go test cache
 	go clean -testcache
 
-clean\:all: clean ## Run clean plus remove ./bin (golangci-lint, goimports, etc.)
+clean\:all: clean ## Run clean plus remove ./bin (Go tools)
 	rm -rf $(BIN)
 
 #------------------------------------------------------------------------------
 # Utilities
 #------------------------------------------------------------------------------
 
-versions: ## Show Go, golangci-lint, and goimports versions
+versions: ## Show Go and required tool versions
 	@echo "Go: $$(go version)"
 	@if test -x $(GOLANGCI); then $(GOLANGCI) version; else echo "golangci-lint: not installed (run make setup)"; fi
 	@if test -x $(GOIMPORTS); then echo "goimports (module metadata):"; go version -m $(GOIMPORTS) 2>&1 | head -4; else echo "goimports: not installed (run make setup)"; fi
+	@if test -x $(GOCYCLO); then echo "gocyclo (module metadata):"; go version -m $(GOCYCLO) 2>&1 | head -4; else echo "gocyclo: not installed (run make setup)"; fi


### PR DESCRIPTION
This commit introduces `make cyclo` as a non-blocking, report-only quality gate for cyclomatic complexity.

Changes:
- Add `gocyclo` to `make setup` (pinned at v0.6.0) and install it into `./bin` alongside the other project-local tools
- Add `cyclo` target: runs `gocyclo -over 10 .` after a guard check
- Add `cyclo` to the `.PHONY` list and the `versions` target
- Add a non-blocking `cyclomatic-complexity` CI job that runs `make cyclo`, captures output to `cyclo.txt`, and uploads it as a workflow artifact
- Update `AGENTS.md` to document `make cyclo`, the `-over 10` threshold, how it relates to the Go Report Card badge, and that CI uploads `cyclo.txt` as a non-failing artifact
- Minor help-text/comment cleanups across `Makefile` targets