### PR TITLE
Address cyclomatic complexity threshold violations repo-wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,19 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.3
+
+  cyclomatic-complexity:
+    name: cyclomatic-complexity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Generate gocyclo report (non-blocking)
+        run: make setup && ( make cyclo 2>&1 | tee cyclo.txt; exit 0 )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cyclomatic-complexity
+          path: cyclo.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,8 @@ func jsonResult(v any) (*mcp.CallToolResult, error) {
 | `findTopicByID(root, id)` | First topic matching `id` in DFS order |
 | `ancestryPath(root, targetID)` | Titles from root to (not including) the target; `nil` if target is root or not found |
 | `findParentOfTopic(root, targetID)` | Parent topic, child index, and list name (`"attached"`, `"detached"`, `"summary"`) |
+| `findDirectChildInLists(parent, targetID)` | If `targetID` is an immediate child of `parent`, returns its index and list name; else `ok` false |
+| `searchChildrenForParent(root, targetID)` | Depth-first: recurse into attached, detached, summary to find which child subtree contains `targetID`’s parent |
 | `isDescendantOf(ancestor, descendantID)` | Reports whether a node is the ancestor or any node in its subtree |
 | `countTopics(t)` | Total node count for a subtree (self + all descendants) |
 | `deepCloneTopic(root)` | JSON round-trip clone of a subtree, then fresh UUIDs for topics and summary/boundary descriptors |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Dockerfile                — multi-stage image (Alpine build, distroless runtim
 .dockerignore             — Docker build context exclusions
 .github/
   workflows/
-    ci.yml                — test and lint on push and PR
+    ci.yml                — test, lint, and cyclomatic-complexity report artifact on push and PR
     docker-publish.yml    — multi-platform image build and push to GHCR
 cmd/
   xmind-mcp/
@@ -245,6 +245,8 @@ For zip and JSON handling, use Go stdlib only: `archive/zip` and `encoding/json`
 ### Verification before you finish
 
 Treat a change as incomplete until **`make build test lint`** passes locally. The Makefile runs **golangci-lint** (including **revive**); do not rely on `go test` alone to catch style and API-surface rules.
+
+**Cyclomatic complexity (report-only):** After `make setup`, **`make cyclo`** runs [gocyclo](https://github.com/fzipp/gocyclo) with **`-over 10`** on the module tree (`gocyclo` takes a directory path, not a Go package pattern—see the Makefile). It lists functions with complexity **strictly greater than 10** (including `*_test.go`). This is a stricter bar than [Go Report Card](https://goreportcard.com/)’s public check (**cyclo-over=15**); the badge’s **percentage is file-based** (any over-threshold function fails the file), while the CLI lists **individual functions**, so do not expect the same headline number. CI uploads a **`cyclo.txt`** artifact from a **non-blocking** job; it does not fail the workflow when violations exist.
 
 Also verify that documentation reflects the change before finishing. Update **`AGENTS.md`**, **`.cursor/rules/`**, and **`.cursor/skills/`** as needed:
 

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,14 @@ MODULE      := github.com/mab-go/xmind-mcp
 VERSION_PKG := $(MODULE)/internal/version
 GOLANGCI    := $(BIN)/golangci-lint
 GOIMPORTS   := $(BIN)/goimports
+GOCYCLO     := $(BIN)/gocyclo
 # Pinned golangci-lint release for reproducible `make lint`; bump if unsupported on current Go (see go.mod).
 # v2.6.x binaries were built with Go 1.25 and reject go.mod go 1.26+; use v2.9+ for Go 1.26 toolchains.
 GOLANGCI_LINT_VERSION ?= v2.11.3
 # Pinned goimports (golang.org/x/tools); bump if `make fmt` fails or is incompatible with go.mod Go version.
 GOIMPORTS_VERSION ?= v0.38.0
+# Pinned gocyclo (github.com/fzipp/gocyclo); bump for `make cyclo` reproducibility.
+GOCYCLO_VERSION ?= v0.6.0
 
 # golangci-lint must be built with Go >= go.mod; auto follows deps' older go version, so pin to module Go.
 GO_MOD_VERSION := $(shell grep -E '^go ' go.mod | head -1 | awk '{print $$2}')
@@ -33,7 +36,7 @@ OPEN ?= $(shell command -v xdg-open 2>/dev/null || echo "open")
         setup \
         build install run gen-example \
         test test\:cover \
-        lint lint\:fix fmt vet \
+        lint lint\:fix fmt vet cyclo \
         mod\:tidy mod\:verify \
         clean clean\:cache clean\:all \
         versions
@@ -72,12 +75,13 @@ help: ## Show available commands
 # Setup
 #------------------------------------------------------------------------------
 
-setup: ## Install golangci-lint and goimports into ./bin (project-local)
+setup: ## Install required Go tools into ./bin (project-local)
 	@mkdir -p $(BIN)
 	GOTOOLCHAIN=$(TOOLCHAIN_FOR_TOOLS) GOBIN=$(abspath $(BIN)) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	GOTOOLCHAIN=$(TOOLCHAIN_FOR_TOOLS) GOBIN=$(abspath $(BIN)) go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+	GOTOOLCHAIN=$(TOOLCHAIN_FOR_TOOLS) GOBIN=$(abspath $(BIN)) go install github.com/fzipp/gocyclo/cmd/gocyclo@$(GOCYCLO_VERSION)
 	@echo ""
-	@echo "Setup complete: $(GOLANGCI), $(GOIMPORTS)"
+	@echo "Setup complete: $(GOLANGCI), $(GOIMPORTS), $(GOCYCLO)"
 	@echo ""
 
 #------------------------------------------------------------------------------
@@ -88,7 +92,7 @@ build: ## Build binary to ./bin/xmind-mcp with version ldflags
 	@mkdir -p $(BIN)
 	go build -o $(BINARY) -ldflags "$(LDFLAGS)" ./cmd/xmind-mcp
 
-install: ## Run go install with same ldflags (installs to GOPATH/bin or GOBIN)
+install: ## Run go install with same ldflags as 'build' target
 	go install -ldflags "$(LDFLAGS)" ./cmd/xmind-mcp
 
 #------------------------------------------------------------------------------
@@ -99,7 +103,7 @@ run: ## Run via go run (optional: ARGS="--flags")
 	go run -ldflags "$(LDFLAGS)" ./cmd/xmind-mcp $(ARGS)
 
 OUT ?= docs/example.xmind
-gen-example: ## Generate example mind map to docs/example.xmind (override: OUT=path/to/file.xmind)
+gen-example: ## Write example mind map to docs/example.xmind (override: OUT=...)
 	go run ./cmd/gen-example $(OUT)
 
 #------------------------------------------------------------------------------
@@ -126,12 +130,16 @@ lint\:fix: ## Run golangci-lint with --fix
 	@test -x $(GOLANGCI) || (echo "Run 'make setup' to install golangci-lint" && exit 1)
 	$(GOLANGCI) run --fix ./...
 
-fmt: ## Format with goimports (gofmt + import fixes; -l lists changed files, -w writes)
+fmt: ## Format with goimports (gofmt + import fixes)
 	@test -x $(GOIMPORTS) || (echo "Run 'make setup' to install goimports into ./bin" && exit 1)
 	$(GOIMPORTS) -l -w .
 
 vet: ## Run go vet
 	go vet ./...
+
+cyclo: ## Run gocyclo; run 'make setup' first
+	@test -x $(GOCYCLO) || (echo "Run 'make setup' to install gocyclo" && exit 1)
+	$(GOCYCLO) -over 10 .
 
 #------------------------------------------------------------------------------
 # Module
@@ -153,14 +161,15 @@ clean: ## Remove built binary and coverage artifacts
 clean\:cache: ## Clear Go test cache
 	go clean -testcache
 
-clean\:all: clean ## Run clean plus remove ./bin (golangci-lint, goimports, etc.)
+clean\:all: clean ## Run clean plus remove ./bin (Go tools)
 	rm -rf $(BIN)
 
 #------------------------------------------------------------------------------
 # Utilities
 #------------------------------------------------------------------------------
 
-versions: ## Show Go, golangci-lint, and goimports versions
+versions: ## Show Go and required tool versions
 	@echo "Go: $$(go version)"
 	@if test -x $(GOLANGCI); then $(GOLANGCI) version; else echo "golangci-lint: not installed (run make setup)"; fi
 	@if test -x $(GOIMPORTS); then echo "goimports (module metadata):"; go version -m $(GOIMPORTS) 2>&1 | head -4; else echo "goimports: not installed (run make setup)"; fi
+	@if test -x $(GOCYCLO); then echo "gocyclo (module metadata):"; go version -m $(GOCYCLO) 2>&1 | head -4; else echo "gocyclo: not installed (run make setup)"; fi

--- a/internal/server/handler/find.go
+++ b/internal/server/handler/find.go
@@ -135,6 +135,72 @@ func parseBoolOptional(args map[string]any, key string) (bool, *mcp.CallToolResu
 	return false, nil
 }
 
+// requireSheetIDFromArgs reads and validates args["sheet_id"] like GetSubtree/FindTopic.
+func requireSheetIDFromArgs(args map[string]any) (sheetID string, toolErr *mcp.CallToolResult) {
+	rawSheet, ok := args["sheet_id"]
+	if !ok {
+		return "", mcp.NewToolResultError("missing required argument: sheet_id")
+	}
+	sid, ok := rawSheet.(string)
+	if !ok || sid == "" {
+		return "", mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string")
+	}
+	return sid, nil
+}
+
+// getSubtreeRootFromArgs resolves the subtree root from optional topic_id (empty string = sheet root).
+func getSubtreeRootFromArgs(sh *xmind.Sheet, args map[string]any) (root *xmind.Topic, toolErr *mcp.CallToolResult) {
+	if v, has := args["topic_id"]; has && v != nil {
+		rawTopic, ok := v.(string)
+		if !ok {
+			return nil, mcp.NewToolResultError("invalid argument topic_id: expected a string")
+		}
+		if rawTopic != "" {
+			t := findTopicByID(&sh.RootTopic, rawTopic)
+			if t == nil {
+				return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", rawTopic))
+			}
+			return t, nil
+		}
+	}
+	return &sh.RootTopic, nil
+}
+
+// readMapAndSheet loads the workbook and returns the sheet with sheetID.
+func readMapAndSheet(absPath, sheetID string) (*xmind.Sheet, *mcp.CallToolResult, error) {
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if toolErr2 != nil {
+		return nil, toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+	return sh, nil, nil
+}
+
+func getSubtreeDepthAndOpts(args map[string]any) (maxDepth *int, opts subtreeOpts, toolErr *mcp.CallToolResult) {
+	if raw, has := args["depth"]; has {
+		md, derr := parseDepthOptional(raw)
+		if derr != nil {
+			return nil, subtreeOpts{}, derr
+		}
+		maxDepth = md
+	}
+	includeNotes, berr := parseBoolOptional(args, "include_notes")
+	if berr != nil {
+		return nil, subtreeOpts{}, berr
+	}
+	includeLinks, berr2 := parseBoolOptional(args, "include_links")
+	if berr2 != nil {
+		return nil, subtreeOpts{}, berr2
+	}
+	return maxDepth, subtreeOpts{includeNotes: includeNotes, includeLinks: includeLinks}, nil
+}
+
 // GetSubtree returns a JSON subtree from the sheet root or a topic id.
 func (h *XMindHandler) GetSubtree(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
@@ -144,64 +210,28 @@ func (h *XMindHandler) GetSubtree(ctx context.Context, req mcp.CallToolRequest) 
 		return toolErr, nil
 	}
 
-	rawSheet, ok := args["sheet_id"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: sheet_id"), nil
-	}
-	sheetID, ok := rawSheet.(string)
-	if !ok || sheetID == "" {
-		return mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string"), nil
+	sheetID, serr := requireSheetIDFromArgs(args)
+	if serr != nil {
+		return serr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sh, teRead, err := readMapAndSheet(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
+	if teRead != nil {
+		return teRead, nil
 	}
 
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	root, rerr := getSubtreeRootFromArgs(sh, args)
+	if rerr != nil {
+		return rerr, nil
 	}
 
-	var root *xmind.Topic
-	if v, has := args["topic_id"]; has && v != nil {
-		rawTopic, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument topic_id: expected a string"), nil
-		}
-		if rawTopic != "" {
-			t := findTopicByID(&sh.RootTopic, rawTopic)
-			if t == nil {
-				return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", rawTopic)), nil
-			}
-			root = t
-		}
+	maxDepth, opts, derr := getSubtreeDepthAndOpts(args)
+	if derr != nil {
+		return derr, nil
 	}
-	if root == nil {
-		root = &sh.RootTopic
-	}
-
-	var maxDepth *int
-	if raw, has := args["depth"]; has {
-		md, derr := parseDepthOptional(raw)
-		if derr != nil {
-			return derr, nil
-		}
-		maxDepth = md
-	}
-
-	includeNotes, berr := parseBoolOptional(args, "include_notes")
-	if berr != nil {
-		return berr, nil
-	}
-	includeLinks, berr2 := parseBoolOptional(args, "include_links")
-	if berr2 != nil {
-		return berr2, nil
-	}
-	opts := subtreeOpts{includeNotes: includeNotes, includeLinks: includeLinks}
 
 	node := topicToSubtree(root, 0, maxDepth, opts)
 	out, err := json.Marshal(node)
@@ -225,6 +255,48 @@ type searchTopicItem struct {
 	AncestryPath []string `json:"ancestryPath"`
 	ParentTitle  string   `json:"parentTitle"`
 	Depth        int      `json:"depth"`
+}
+
+// searchSheetsScopeFromArgs returns sheets to search and whether to attach sheet metadata per match.
+func searchSheetsScopeFromArgs(sheets []xmind.Sheet, args map[string]any) (toSearch []xmind.Sheet, includeSheetMetadata bool, toolErr *mcp.CallToolResult) {
+	if raw, has := args["sheet_id"]; has && raw != nil {
+		sheetID, ok := raw.(string)
+		if !ok || sheetID == "" {
+			return nil, false, mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string")
+		}
+		sh := findSheetByID(sheets, sheetID)
+		if sh == nil {
+			return nil, false, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID))
+		}
+		return []xmind.Sheet{*sh}, false, nil
+	}
+	return sheets, true, nil
+}
+
+func collectSearchTopicMatches(sh *xmind.Sheet, qLower string, includeSheetMetadata bool) []searchTopicItem {
+	var matches []searchTopicItem
+	walkTopics(&sh.RootTopic, 0, nil, func(t *xmind.Topic, depth int, parent *xmind.Topic) bool {
+		if strings.Contains(strings.ToLower(t.Title), qLower) {
+			pt := ""
+			if parent != nil {
+				pt = parent.Title
+			}
+			item := searchTopicItem{
+				ID:           t.ID,
+				Title:        t.Title,
+				AncestryPath: ancestryPath(&sh.RootTopic, t.ID),
+				ParentTitle:  pt,
+				Depth:        depth,
+			}
+			if includeSheetMetadata {
+				item.SheetID = sh.ID
+				item.SheetTitle = sh.Title
+			}
+			matches = append(matches, item)
+		}
+		return true
+	})
+	return matches
 }
 
 // SearchTopics finds topics whose title contains the query (case-insensitive).
@@ -257,49 +329,16 @@ func (h *XMindHandler) SearchTopics(ctx context.Context, req mcp.CallToolRequest
 		return toolErr2, nil
 	}
 
-	// Determine which sheets to search.
-	allSheets := false
-	var sheetsToSearch []xmind.Sheet
-	if raw, has := args["sheet_id"]; has && raw != nil {
-		sheetID, ok := raw.(string)
-		if !ok || sheetID == "" {
-			return mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string"), nil
-		}
-		sh := findSheetByID(sheets, sheetID)
-		if sh == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-		}
-		sheetsToSearch = []xmind.Sheet{*sh}
-	} else {
-		sheetsToSearch = sheets
-		allSheets = true
+	sheetsToSearch, allSheets, scopeErr := searchSheetsScopeFromArgs(sheets, args)
+	if scopeErr != nil {
+		return scopeErr, nil
 	}
 
 	qLower := strings.ToLower(query)
 	var matches []searchTopicItem
 	for i := range sheetsToSearch {
 		sh := &sheetsToSearch[i]
-		walkTopics(&sh.RootTopic, 0, nil, func(t *xmind.Topic, depth int, parent *xmind.Topic) bool {
-			if strings.Contains(strings.ToLower(t.Title), qLower) {
-				pt := ""
-				if parent != nil {
-					pt = parent.Title
-				}
-				item := searchTopicItem{
-					ID:           t.ID,
-					Title:        t.Title,
-					AncestryPath: ancestryPath(&sh.RootTopic, t.ID),
-					ParentTitle:  pt,
-					Depth:        depth,
-				}
-				if allSheets {
-					item.SheetID = sh.ID
-					item.SheetTitle = sh.Title
-				}
-				matches = append(matches, item)
-			}
-			return true
-		})
+		matches = append(matches, collectSearchTopicMatches(sh, qLower, allSheets)...)
 	}
 
 	resp := searchTopicsResponse{
@@ -369,68 +408,41 @@ func childTitlesInWalkOrder(t *xmind.Topic) []string {
 	return out
 }
 
-// FindTopic returns the first topic with an exact case-sensitive title (preorder DFS).
-// If parent_id is set, the walk starts at that topic (which may itself match).
-func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	_ = ctx
-	args := req.GetArguments()
-	absPath, toolErr := absPathFromArgs(args)
-	if toolErr != nil {
-		return toolErr, nil
-	}
-
-	rawSheet, ok := args["sheet_id"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: sheet_id"), nil
-	}
-	sheetID, ok := rawSheet.(string)
-	if !ok || sheetID == "" {
-		return mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string"), nil
-	}
-
-	rawTitle, ok := args["title"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: title"), nil
-	}
-	wantTitle, ok := rawTitle.(string)
-	if !ok {
-		return mcp.NewToolResultError("invalid argument title: expected a string"), nil
-	}
-	if wantTitle == "" {
-		return mcp.NewToolResultError("invalid argument title: expected a non-empty string"), nil
-	}
-
-	sheets, toolErr2, err := statAndReadMap(absPath)
-	if err != nil {
-		return nil, err
-	}
-	if toolErr2 != nil {
-		return toolErr2, nil
-	}
-
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-
-	searchRoot := &sh.RootTopic
+// findTopicSearchRoot returns the topic at which to start the FindTopic walk (sheet root or parent_id subtree).
+func findTopicSearchRoot(sh *xmind.Sheet, args map[string]any) (searchRoot *xmind.Topic, toolErr *mcp.CallToolResult) {
 	if v, has := args["parent_id"]; has && v != nil {
 		pid, ok := v.(string)
 		if !ok {
-			return mcp.NewToolResultError("invalid argument parent_id: expected a string"), nil
+			return nil, mcp.NewToolResultError("invalid argument parent_id: expected a string")
 		}
 		if pid == "" {
-			return mcp.NewToolResultError("invalid argument parent_id: expected a non-empty string"), nil
+			return nil, mcp.NewToolResultError("invalid argument parent_id: expected a non-empty string")
 		}
 		topic := findTopicByID(&sh.RootTopic, pid)
 		if topic == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", pid)), nil
+			return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", pid))
 		}
-		searchRoot = topic
+		return topic, nil
 	}
+	return &sh.RootTopic, nil
+}
 
-	var found *xmind.Topic
-	var foundParent *xmind.Topic
+func requireFindTopicTitleArgs(args map[string]any) (wantTitle string, toolErr *mcp.CallToolResult) {
+	rawTitle, ok := args["title"]
+	if !ok {
+		return "", mcp.NewToolResultError("missing required argument: title")
+	}
+	title, ok := rawTitle.(string)
+	if !ok {
+		return "", mcp.NewToolResultError("invalid argument title: expected a string")
+	}
+	if title == "" {
+		return "", mcp.NewToolResultError("invalid argument title: expected a non-empty string")
+	}
+	return title, nil
+}
+
+func findFirstTopicByExactTitle(searchRoot *xmind.Topic, wantTitle string) (found *xmind.Topic, foundParent *xmind.Topic) {
 	walkTopics(searchRoot, 0, nil, func(t *xmind.Topic, _ int, parent *xmind.Topic) bool {
 		if t.Title == wantTitle {
 			found = t
@@ -439,11 +451,10 @@ func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (
 		}
 		return true
 	})
+	return found, foundParent
+}
 
-	if found == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: no topic with title %q", wantTitle)), nil
-	}
-
+func findTopicResponseFromMatch(sh *xmind.Sheet, found, foundParent *xmind.Topic) findTopicResponse {
 	resp := findTopicResponse{
 		ID:           found.ID,
 		Title:        found.Title,
@@ -454,6 +465,56 @@ func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (
 		resp.SiblingTitles = siblingTitlesInWalkOrder(foundParent, found.ID)
 	}
 	resp.ChildrenTitles = childTitlesInWalkOrder(found)
+	return resp
+}
+
+func findTopicWorkflow(absPath, sheetID string, args map[string]any, wantTitle string) (findTopicResponse, *mcp.CallToolResult, error) {
+	var zero findTopicResponse
+	sh, te, err := readMapAndSheet(absPath, sheetID)
+	if err != nil {
+		return zero, nil, err
+	}
+	if te != nil {
+		return zero, te, nil
+	}
+	searchRoot, re := findTopicSearchRoot(sh, args)
+	if re != nil {
+		return zero, re, nil
+	}
+	found, par := findFirstTopicByExactTitle(searchRoot, wantTitle)
+	if found == nil {
+		return zero, mcp.NewToolResultError(fmt.Sprintf("topic not found: no topic with title %q", wantTitle)), nil
+	}
+	return findTopicResponseFromMatch(sh, found, par), nil, nil
+}
+
+// FindTopic returns the first topic with an exact case-sensitive title (preorder DFS).
+// If parent_id is set, the walk starts at that topic (which may itself match).
+func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	args := req.GetArguments()
+	absPath, toolErr := absPathFromArgs(args)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+
+	sheetID, serr := requireSheetIDFromArgs(args)
+	if serr != nil {
+		return serr, nil
+	}
+
+	wantTitle, terr := requireFindTopicTitleArgs(args)
+	if terr != nil {
+		return terr, nil
+	}
+
+	resp, te, err := findTopicWorkflow(absPath, sheetID, args, wantTitle)
+	if err != nil {
+		return nil, err
+	}
+	if te != nil {
+		return te, nil
+	}
 
 	out, err := json.Marshal(resp)
 	if err != nil {
@@ -504,10 +565,7 @@ type topicPropertiesChildCounts struct {
 	Summary  int `json:"summary,omitempty"`
 }
 
-func topicPropertiesResponseFrom(sh *xmind.Sheet, topic *xmind.Topic) topicPropertiesResponse {
-	if topic == nil {
-		return topicPropertiesResponse{}
-	}
+func topicPropertiesBase(topic *xmind.Topic) topicPropertiesResponse {
 	out := topicPropertiesResponse{
 		ID:             topic.ID,
 		Title:          topic.Title,
@@ -519,6 +577,10 @@ func topicPropertiesResponseFrom(sh *xmind.Sheet, topic *xmind.Topic) topicPrope
 	if len(topic.Markers) > 0 {
 		out.Markers = append([]xmind.Marker(nil), topic.Markers...)
 	}
+	return out
+}
+
+func applyTopicPropertiesMedia(out *topicPropertiesResponse, topic *xmind.Topic) {
 	if plain := plainNoteContent(topic); plain != "" {
 		out.Notes = plain
 	}
@@ -531,56 +593,85 @@ func topicPropertiesResponseFrom(sh *xmind.Sheet, topic *xmind.Topic) topicPrope
 	if topic.Position != nil {
 		out.Position = &topicPropertiesPosition{X: topic.Position.X, Y: topic.Position.Y}
 	}
-	if n := len(topic.Boundaries); n > 0 {
-		out.BoundaryCount = n
-		out.Boundaries = make([]topicPropertiesBoundary, 0, n)
-		for i := range topic.Boundaries {
-			b := &topic.Boundaries[i]
-			out.Boundaries = append(out.Boundaries, topicPropertiesBoundary{
-				ID:    b.ID,
-				Range: b.Range,
-				Title: b.Title,
-			})
-		}
+}
+
+func applyTopicPropertiesBoundaries(out *topicPropertiesResponse, topic *xmind.Topic) {
+	n := len(topic.Boundaries)
+	if n == 0 {
+		return
 	}
+	out.BoundaryCount = n
+	out.Boundaries = make([]topicPropertiesBoundary, 0, n)
+	for i := range topic.Boundaries {
+		b := &topic.Boundaries[i]
+		out.Boundaries = append(out.Boundaries, topicPropertiesBoundary{
+			ID:    b.ID,
+			Range: b.Range,
+			Title: b.Title,
+		})
+	}
+}
+
+func applyTopicPropertiesSummaryCount(out *topicPropertiesResponse, topic *xmind.Topic) {
 	if sc := len(topic.Summaries); sc > 0 {
 		out.SummaryCount = sc
 	}
-	if sh != nil && len(sh.Relationships) > 0 {
-		for i := range sh.Relationships {
-			rel := &sh.Relationships[i]
-			if rel.End1ID != topic.ID && rel.End2ID != topic.ID {
-				continue
-			}
-			item := topicPropertiesRelationship{
-				ID:     rel.ID,
-				End1ID: rel.End1ID,
-				End2ID: rel.End2ID,
-			}
-			if rel.Title != "" {
-				item.Title = rel.Title
-			}
-			out.Relationships = append(out.Relationships, item)
-		}
+}
+
+func appendTopicRelationshipsForTopic(out *topicPropertiesResponse, sh *xmind.Sheet, topicID string) {
+	if sh == nil || len(sh.Relationships) == 0 {
+		return
 	}
-	if topic.Children != nil {
-		a := len(topic.Children.Attached)
-		d := len(topic.Children.Detached)
-		s := len(topic.Children.Summary)
-		if a > 0 || d > 0 || s > 0 {
-			cc := &topicPropertiesChildCounts{}
-			if a > 0 {
-				cc.Attached = a
-			}
-			if d > 0 {
-				cc.Detached = d
-			}
-			if s > 0 {
-				cc.Summary = s
-			}
-			out.ChildCounts = cc
+	for i := range sh.Relationships {
+		rel := &sh.Relationships[i]
+		if rel.End1ID != topicID && rel.End2ID != topicID {
+			continue
 		}
+		item := topicPropertiesRelationship{
+			ID:     rel.ID,
+			End1ID: rel.End1ID,
+			End2ID: rel.End2ID,
+		}
+		if rel.Title != "" {
+			item.Title = rel.Title
+		}
+		out.Relationships = append(out.Relationships, item)
 	}
+}
+
+func topicChildCountsForResponse(topic *xmind.Topic) *topicPropertiesChildCounts {
+	if topic.Children == nil {
+		return nil
+	}
+	a := len(topic.Children.Attached)
+	d := len(topic.Children.Detached)
+	s := len(topic.Children.Summary)
+	if a == 0 && d == 0 && s == 0 {
+		return nil
+	}
+	cc := &topicPropertiesChildCounts{}
+	if a > 0 {
+		cc.Attached = a
+	}
+	if d > 0 {
+		cc.Detached = d
+	}
+	if s > 0 {
+		cc.Summary = s
+	}
+	return cc
+}
+
+func topicPropertiesResponseFrom(sh *xmind.Sheet, topic *xmind.Topic) topicPropertiesResponse {
+	if topic == nil {
+		return topicPropertiesResponse{}
+	}
+	out := topicPropertiesBase(topic)
+	applyTopicPropertiesMedia(&out, topic)
+	applyTopicPropertiesBoundaries(&out, topic)
+	applyTopicPropertiesSummaryCount(&out, topic)
+	appendTopicRelationshipsForTopic(&out, sh, topic.ID)
+	out.ChildCounts = topicChildCountsForResponse(topic)
 	return out
 }
 

--- a/internal/server/handler/find_test.go
+++ b/internal/server/handler/find_test.go
@@ -61,6 +61,161 @@ func assertSubtreeNoHrefField(t *testing.T, n *subtreeNode) {
 	}
 }
 
+func mustGetSubtreeJSON(t *testing.T, h *XMindHandler, args map[string]any) subtreeNode {
+	t.Helper()
+	res := callTool(t, h.GetSubtree, args)
+	if res.IsError {
+		t.Fatalf("GetSubtree: %s", textContent(t, res))
+	}
+	var node subtreeNode
+	if err := json.Unmarshal([]byte(textContent(t, res)), &node); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return node
+}
+
+func mustGetTopicPropertiesJSON(t *testing.T, h *XMindHandler, path, sheetID, topicID string) topicPropertiesResponse {
+	t.Helper()
+	res := callTool(t, h.GetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sheetID, "topic_id": topicID,
+	})
+	if res.IsError {
+		t.Fatalf("GetTopicProperties: %s", textContent(t, res))
+	}
+	var out topicPropertiesResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return out
+}
+
+func rootTopicIDForSheetTitle(t *testing.T, title string) string {
+	t.Helper()
+	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
+	if err != nil {
+		t.Fatalf("ReadMap: %v", err)
+	}
+	for i := range sheets {
+		if sheets[i].Title == title {
+			return sheets[i].RootTopic.ID
+		}
+	}
+	t.Fatalf("sheet not found: %s", title)
+	return ""
+}
+
+type kitchenSinkTopicRefs struct {
+	boundarySheetID, boundaryTopicID string
+	summarySheetID, summaryTopicID   string
+	posSheetID, posTopicID           string
+}
+
+func updateKitchenSinkTopicRefs(refs *kitchenSinkTopicRefs, sh *xmind.Sheet, topic *xmind.Topic) {
+	if refs.boundarySheetID == "" && len(topic.Boundaries) > 0 {
+		refs.boundarySheetID = sh.ID
+		refs.boundaryTopicID = topic.ID
+	}
+	if refs.summarySheetID == "" && len(topic.Summaries) > 0 {
+		refs.summarySheetID = sh.ID
+		refs.summaryTopicID = topic.ID
+	}
+	if refs.posSheetID == "" && topic.Position != nil {
+		refs.posSheetID = sh.ID
+		refs.posTopicID = topic.ID
+	}
+}
+
+func requireKitchenSinkTopicRefs(t *testing.T, refs *kitchenSinkTopicRefs) {
+	t.Helper()
+	if refs.boundarySheetID == "" || refs.boundaryTopicID == "" {
+		t.Fatal("kitchen-sink fixture must include a topic with boundaries (see AGENTS.md test fixture)")
+	}
+	if refs.summarySheetID == "" || refs.summaryTopicID == "" {
+		t.Fatal("kitchen-sink fixture must include a topic with summaries (see AGENTS.md test fixture)")
+	}
+	if refs.posSheetID == "" || refs.posTopicID == "" {
+		t.Fatal("kitchen-sink fixture must include a topic with position (floating topic; see AGENTS.md test fixture)")
+	}
+}
+
+func scanKitchenSinkBoundarySummaryPosition(t *testing.T, sheets []xmind.Sheet) kitchenSinkTopicRefs {
+	t.Helper()
+	var refs kitchenSinkTopicRefs
+	for si := range sheets {
+		sh := &sheets[si]
+		walkTopics(&sh.RootTopic, 0, nil, func(topic *xmind.Topic, _ int, _ *xmind.Topic) bool {
+			updateKitchenSinkTopicRefs(&refs, sh, topic)
+			return true
+		})
+	}
+	requireKitchenSinkTopicRefs(t, &refs)
+	return refs
+}
+
+func assertBoundaryTopicPropertiesNonEmpty(t *testing.T, out topicPropertiesResponse) {
+	t.Helper()
+	if out.BoundaryCount != len(out.Boundaries) || out.BoundaryCount < 1 {
+		t.Fatalf("boundaryCount/boundaries: %+v", out)
+	}
+}
+
+func assertSummaryTopicPropertiesNonEmpty(t *testing.T, out topicPropertiesResponse) {
+	t.Helper()
+	if out.SummaryCount < 1 {
+		t.Fatalf("summaryCount: got %+v", out)
+	}
+}
+
+func assertPositionTopicPropertiesPresent(t *testing.T, out topicPropertiesResponse) {
+	t.Helper()
+	if out.Position == nil {
+		t.Fatal("expected position on floating topic")
+	}
+}
+
+func relationshipsSheetOrFatal(t *testing.T, sheets []xmind.Sheet) *xmind.Sheet {
+	t.Helper()
+	for i := range sheets {
+		if sheets[i].ID == kitchenSinkRelationshipsSheetID {
+			return &sheets[i]
+		}
+	}
+	t.Fatal("relationships sheet not found")
+	return nil
+}
+
+func countRelationshipsInvolvingEnd(sh *xmind.Sheet, endID string) int {
+	n := 0
+	for i := range sh.Relationships {
+		r := &sh.Relationships[i]
+		if r.End1ID == endID || r.End2ID == endID {
+			n++
+		}
+	}
+	return n
+}
+
+func assertTopicPropertiesRelationshipsMatchSheet(t *testing.T, sh *xmind.Sheet, end1 string, out topicPropertiesResponse) {
+	t.Helper()
+	byID := make(map[string]topicPropertiesRelationship, len(out.Relationships))
+	for _, r := range out.Relationships {
+		byID[r.ID] = r
+	}
+	for i := range sh.Relationships {
+		r := &sh.Relationships[i]
+		if r.End1ID != end1 && r.End2ID != end1 {
+			continue
+		}
+		got, ok := byID[r.ID]
+		if !ok {
+			t.Fatalf("missing relationship id %s in response", r.ID)
+		}
+		if got.End1ID != r.End1ID || got.End2ID != r.End2ID {
+			t.Fatalf("endpoint mismatch for %s: got %+v want End1=%q End2=%q", r.ID, got, r.End1ID, r.End2ID)
+		}
+	}
+}
+
 func firstKitchenSinkSheetID(t *testing.T) string {
 	t.Helper()
 	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
@@ -642,19 +797,10 @@ func TestGetSubtreeDepthZero(t *testing.T) {
 
 func TestGetSubtreeSheet10StructureClassNotesHref(t *testing.T) {
 	h := NewXMindHandler()
+	path := kitchenSinkPath(t)
 	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet10Title)
 
-	res := callTool(t, h.GetSubtree, map[string]any{
-		"path":     kitchenSinkPath(t),
-		"sheet_id": sid,
-	})
-	if res.IsError {
-		t.Fatalf("GetSubtree: %s", textContent(t, res))
-	}
-	var root subtreeNode
-	if err := json.Unmarshal([]byte(textContent(t, res)), &root); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	root := mustGetSubtreeJSON(t, h, map[string]any{"path": path, "sheet_id": sid})
 	if root.Title != "Central Topic" {
 		t.Fatalf("title: %q", root.Title)
 	}
@@ -662,66 +808,26 @@ func TestGetSubtreeSheet10StructureClassNotesHref(t *testing.T) {
 		t.Fatalf("structureClass: got %q", root.StructureClass)
 	}
 
-	resNotes := callTool(t, h.GetSubtree, map[string]any{
-		"path":          kitchenSinkPath(t),
-		"sheet_id":      sid,
-		"topic_id":      kitchenSinkSheet10NoteTopicID,
-		"include_notes": true,
+	noteNode := mustGetSubtreeJSON(t, h, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": kitchenSinkSheet10NoteTopicID, "include_notes": true,
 	})
-	if resNotes.IsError {
-		t.Fatalf("GetSubtree: %s", textContent(t, resNotes))
-	}
-	var noteNode subtreeNode
-	if err := json.Unmarshal([]byte(textContent(t, resNotes)), &noteNode); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
 	if !strings.HasPrefix(noteNode.Notes, "This is a simple, plain text note") {
 		t.Fatalf("notes: %q", noteNode.Notes)
 	}
 
-	resNoNotes := callTool(t, h.GetSubtree, map[string]any{
-		"path":          kitchenSinkPath(t),
-		"sheet_id":      sid,
-		"topic_id":      kitchenSinkSheet10NoteTopicID,
-		"include_notes": false,
+	noNotesTree := mustGetSubtreeJSON(t, h, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": kitchenSinkSheet10NoteTopicID, "include_notes": false,
 	})
-	if resNoNotes.IsError {
-		t.Fatalf("GetSubtree: %s", textContent(t, resNoNotes))
-	}
-	var noNotesTree subtreeNode
-	if err := json.Unmarshal([]byte(textContent(t, resNoNotes)), &noNotesTree); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
 	assertSubtreeNoNotesField(t, &noNotesTree)
 
-	resNoHref := callTool(t, h.GetSubtree, map[string]any{
-		"path":          kitchenSinkPath(t),
-		"sheet_id":      sid,
-		"topic_id":      kitchenSinkSheet10HrefTopicID,
-		"include_links": false,
+	noHrefTree := mustGetSubtreeJSON(t, h, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": kitchenSinkSheet10HrefTopicID, "include_links": false,
 	})
-	if resNoHref.IsError {
-		t.Fatalf("GetSubtree: %s", textContent(t, resNoHref))
-	}
-	var noHrefTree subtreeNode
-	if err := json.Unmarshal([]byte(textContent(t, resNoHref)), &noHrefTree); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
 	assertSubtreeNoHrefField(t, &noHrefTree)
 
-	resHref := callTool(t, h.GetSubtree, map[string]any{
-		"path":          kitchenSinkPath(t),
-		"sheet_id":      sid,
-		"topic_id":      kitchenSinkSheet10HrefTopicID,
-		"include_links": true,
+	hrefNode := mustGetSubtreeJSON(t, h, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": kitchenSinkSheet10HrefTopicID, "include_links": true,
 	})
-	if resHref.IsError {
-		t.Fatalf("GetSubtree: %s", textContent(t, resHref))
-	}
-	var hrefNode subtreeNode
-	if err := json.Unmarshal([]byte(textContent(t, resHref)), &hrefNode); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
 	if hrefNode.Href != "https://www.google.com" {
 		t.Fatalf("href: %q", hrefNode.Href)
 	}
@@ -802,67 +908,21 @@ func TestGetSubtreeDepthWithIncludeFlags(t *testing.T) {
 
 func TestGetTopicPropertiesSheet10NotesHrefStructureClass(t *testing.T) {
 	h := NewXMindHandler()
+	path := kitchenSinkPath(t)
 	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet10Title)
+	rootID := rootTopicIDForSheetTitle(t, kitchenSinkSheet10Title)
 
-	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
-	if err != nil {
-		t.Fatalf("ReadMap: %v", err)
-	}
-	var rootID string
-	for i := range sheets {
-		if sheets[i].Title == kitchenSinkSheet10Title {
-			rootID = sheets[i].RootTopic.ID
-			break
-		}
-	}
-	if rootID == "" {
-		t.Fatal("sheet 10 not found")
-	}
-
-	resRoot := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     kitchenSinkPath(t),
-		"sheet_id": sid,
-		"topic_id": rootID,
-	})
-	if resRoot.IsError {
-		t.Fatalf("GetTopicProperties: %s", textContent(t, resRoot))
-	}
-	var rootProps topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, resRoot)), &rootProps); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	rootProps := mustGetTopicPropertiesJSON(t, h, path, sid, rootID)
 	if rootProps.StructureClass != "org.xmind.ui.map.clockwise" {
 		t.Fatalf("structureClass: got %q", rootProps.StructureClass)
 	}
 
-	resNotes := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     kitchenSinkPath(t),
-		"sheet_id": sid,
-		"topic_id": kitchenSinkSheet10NoteTopicID,
-	})
-	if resNotes.IsError {
-		t.Fatalf("GetTopicProperties: %s", textContent(t, resNotes))
-	}
-	var noteProps topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, resNotes)), &noteProps); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	noteProps := mustGetTopicPropertiesJSON(t, h, path, sid, kitchenSinkSheet10NoteTopicID)
 	if !strings.HasPrefix(noteProps.Notes, "This is a simple, plain text note") {
 		t.Fatalf("notes: %q", noteProps.Notes)
 	}
 
-	resHref := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     kitchenSinkPath(t),
-		"sheet_id": sid,
-		"topic_id": kitchenSinkSheet10HrefTopicID,
-	})
-	if resHref.IsError {
-		t.Fatalf("GetTopicProperties: %s", textContent(t, resHref))
-	}
-	var hrefProps topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, resHref)), &hrefProps); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	hrefProps := mustGetTopicPropertiesJSON(t, h, path, sid, kitchenSinkSheet10HrefTopicID)
 	if hrefProps.Href != "https://www.google.com" {
 		t.Fatalf("href: %q", hrefProps.Href)
 	}
@@ -875,60 +935,18 @@ func TestGetTopicPropertiesRelationshipsFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMap: %v", err)
 	}
-	var sh *xmind.Sheet
-	for i := range sheets {
-		if sheets[i].ID == kitchenSinkRelationshipsSheetID {
-			sh = &sheets[i]
-			break
-		}
-	}
-	if sh == nil {
-		t.Fatal("relationships sheet not found")
-	}
+	sh := relationshipsSheetOrFatal(t, sheets)
 	if len(sh.Relationships) == 0 {
 		t.Fatal("expected at least one relationship on kitchen-sink relationships sheet")
 	}
 	end1 := sh.Relationships[0].End1ID
-	var wantCount int
-	for i := range sh.Relationships {
-		r := &sh.Relationships[i]
-		if r.End1ID == end1 || r.End2ID == end1 {
-			wantCount++
-		}
-	}
+	wantCount := countRelationshipsInvolvingEnd(sh, end1)
 
-	res := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     path,
-		"sheet_id": kitchenSinkRelationshipsSheetID,
-		"topic_id": end1,
-	})
-	if res.IsError {
-		t.Fatalf("GetTopicProperties: %s", textContent(t, res))
-	}
-	var out topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	out := mustGetTopicPropertiesJSON(t, h, path, kitchenSinkRelationshipsSheetID, end1)
 	if len(out.Relationships) != wantCount {
 		t.Fatalf("relationships: got %d want %d", len(out.Relationships), wantCount)
 	}
-	byID := make(map[string]topicPropertiesRelationship, len(out.Relationships))
-	for _, r := range out.Relationships {
-		byID[r.ID] = r
-	}
-	for i := range sh.Relationships {
-		r := &sh.Relationships[i]
-		if r.End1ID != end1 && r.End2ID != end1 {
-			continue
-		}
-		got, ok := byID[r.ID]
-		if !ok {
-			t.Fatalf("missing relationship id %s in response", r.ID)
-		}
-		if got.End1ID != r.End1ID || got.End2ID != r.End2ID {
-			t.Fatalf("endpoint mismatch for %s: got %+v want End1=%q End2=%q", r.ID, got, r.End1ID, r.End2ID)
-		}
-	}
+	assertTopicPropertiesRelationshipsMatchSheet(t, sh, end1, out)
 }
 
 func TestGetTopicPropertiesKitchenSinkBoundarySummaryPosition(t *testing.T) {
@@ -937,86 +955,11 @@ func TestGetTopicPropertiesKitchenSinkBoundarySummaryPosition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMap: %v", err)
 	}
-	var boundarySheetID, boundaryTopicID string
-	var summarySheetID, summaryTopicID string
-	var posSheetID, posTopicID string
-	for si := range sheets {
-		sh := &sheets[si]
-		walkTopics(&sh.RootTopic, 0, nil, func(topic *xmind.Topic, _ int, _ *xmind.Topic) bool {
-			if boundarySheetID == "" && len(topic.Boundaries) > 0 {
-				boundarySheetID = sh.ID
-				boundaryTopicID = topic.ID
-			}
-			if summarySheetID == "" && len(topic.Summaries) > 0 {
-				summarySheetID = sh.ID
-				summaryTopicID = topic.ID
-			}
-			if posSheetID == "" && topic.Position != nil {
-				posSheetID = sh.ID
-				posTopicID = topic.ID
-			}
-			return true
-		})
-	}
-	if boundarySheetID == "" || boundaryTopicID == "" {
-		t.Fatal("kitchen-sink fixture must include a topic with boundaries (see AGENTS.md test fixture)")
-	}
-	if summarySheetID == "" || summaryTopicID == "" {
-		t.Fatal("kitchen-sink fixture must include a topic with summaries (see AGENTS.md test fixture)")
-	}
-	if posSheetID == "" || posTopicID == "" {
-		t.Fatal("kitchen-sink fixture must include a topic with position (floating topic; see AGENTS.md test fixture)")
-	}
-
+	refs := scanKitchenSinkBoundarySummaryPosition(t, sheets)
 	h := NewXMindHandler()
-
-	resB := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     path,
-		"sheet_id": boundarySheetID,
-		"topic_id": boundaryTopicID,
-	})
-	if resB.IsError {
-		t.Fatalf("GetTopicProperties (boundary): %s", textContent(t, resB))
-	}
-	var bOut topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, resB)), &bOut); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if bOut.BoundaryCount != len(bOut.Boundaries) || bOut.BoundaryCount < 1 {
-		t.Fatalf("boundaryCount/boundaries: %+v", bOut)
-	}
-
-	resS := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     path,
-		"sheet_id": summarySheetID,
-		"topic_id": summaryTopicID,
-	})
-	if resS.IsError {
-		t.Fatalf("GetTopicProperties (summary): %s", textContent(t, resS))
-	}
-	var sOut topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, resS)), &sOut); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if sOut.SummaryCount < 1 {
-		t.Fatalf("summaryCount: got %+v", sOut)
-	}
-
-	resP := callTool(t, h.GetTopicProperties, map[string]any{
-		"path":     path,
-		"sheet_id": posSheetID,
-		"topic_id": posTopicID,
-	})
-	if resP.IsError {
-		t.Fatalf("GetTopicProperties (position): %s", textContent(t, resP))
-	}
-	var pOut topicPropertiesResponse
-	if err := json.Unmarshal([]byte(textContent(t, resP)), &pOut); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if pOut.Position == nil {
-		t.Fatal("expected position on floating topic")
-	}
+	assertBoundaryTopicPropertiesNonEmpty(t, mustGetTopicPropertiesJSON(t, h, path, refs.boundarySheetID, refs.boundaryTopicID))
+	assertSummaryTopicPropertiesNonEmpty(t, mustGetTopicPropertiesJSON(t, h, path, refs.summarySheetID, refs.summaryTopicID))
+	assertPositionTopicPropertiesPresent(t, mustGetTopicPropertiesJSON(t, h, path, refs.posSheetID, refs.posTopicID))
 }
 
 func TestGetTopicPropertiesUnknownTopic(t *testing.T) {

--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -205,6 +205,51 @@ func walkTopics(topic *xmind.Topic, depth int, parent *xmind.Topic, fn func(t *x
 	return true
 }
 
+// findDirectChildInLists reports whether targetID is an immediate child of parent and its index/list.
+func findDirectChildInLists(parent *xmind.Topic, targetID string) (idx int, listType string, ok bool) {
+	if parent == nil || parent.Children == nil {
+		return -1, "", false
+	}
+	for i := range parent.Children.Attached {
+		if parent.Children.Attached[i].ID == targetID {
+			return i, "attached", true
+		}
+	}
+	for i := range parent.Children.Detached {
+		if parent.Children.Detached[i].ID == targetID {
+			return i, "detached", true
+		}
+	}
+	for i := range parent.Children.Summary {
+		if parent.Children.Summary[i].ID == targetID {
+			return i, "summary", true
+		}
+	}
+	return -1, "", false
+}
+
+func searchChildrenForParent(root *xmind.Topic, targetID string) (*xmind.Topic, int, string) {
+	if root == nil || root.Children == nil {
+		return nil, -1, ""
+	}
+	for i := range root.Children.Attached {
+		if p, idx, lt := findParentOfTopic(&root.Children.Attached[i], targetID); p != nil {
+			return p, idx, lt
+		}
+	}
+	for i := range root.Children.Detached {
+		if p, idx, lt := findParentOfTopic(&root.Children.Detached[i], targetID); p != nil {
+			return p, idx, lt
+		}
+	}
+	for i := range root.Children.Summary {
+		if p, idx, lt := findParentOfTopic(&root.Children.Summary[i], targetID); p != nil {
+			return p, idx, lt
+		}
+	}
+	return nil, -1, ""
+}
+
 // findParentOfTopic returns the parent of targetID, the child's index within the parent's
 // attached/detached/summary slice, and which list ("attached", "detached", "summary").
 // Returns nil, -1, "" if target is the root, not found, or root is nil.
@@ -215,39 +260,10 @@ func findParentOfTopic(root *xmind.Topic, targetID string) (*xmind.Topic, int, s
 	if root.ID == targetID {
 		return nil, -1, ""
 	}
-	if root.Children != nil {
-		for i := range root.Children.Attached {
-			if root.Children.Attached[i].ID == targetID {
-				return root, i, "attached"
-			}
-		}
-		for i := range root.Children.Detached {
-			if root.Children.Detached[i].ID == targetID {
-				return root, i, "detached"
-			}
-		}
-		for i := range root.Children.Summary {
-			if root.Children.Summary[i].ID == targetID {
-				return root, i, "summary"
-			}
-		}
-		for i := range root.Children.Attached {
-			if p, idx, lt := findParentOfTopic(&root.Children.Attached[i], targetID); p != nil {
-				return p, idx, lt
-			}
-		}
-		for i := range root.Children.Detached {
-			if p, idx, lt := findParentOfTopic(&root.Children.Detached[i], targetID); p != nil {
-				return p, idx, lt
-			}
-		}
-		for i := range root.Children.Summary {
-			if p, idx, lt := findParentOfTopic(&root.Children.Summary[i], targetID); p != nil {
-				return p, idx, lt
-			}
-		}
+	if idx, lt, ok := findDirectChildInLists(root, targetID); ok {
+		return root, idx, lt
 	}
-	return nil, -1, ""
+	return searchChildrenForParent(root, targetID)
 }
 
 // isDescendantOf reports whether descendantID matches the ancestor topic or any node

--- a/internal/server/handler/handler_test.go
+++ b/internal/server/handler/handler_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/mab-go/xmind-mcp/internal/xmind"
 )
 
-func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
-	summaryTopicID := uuid.New().String()
-	root := &xmind.Topic{
+func deepCloneFixtureTopic(summaryTopicID string) *xmind.Topic {
+	return &xmind.Topic{
 		ID: "root-old",
 		Boundaries: []xmind.Boundary{
 			{ID: "bound-old", Range: "(0,0)"},
@@ -22,10 +21,10 @@ func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
 			Summary:  []xmind.Topic{{ID: summaryTopicID, Title: "Sum"}},
 		},
 	}
-	clone, err := deepCloneTopic(root)
-	if err != nil {
-		t.Fatal(err)
-	}
+}
+
+func assertDeepCloneRootAndAttached(t *testing.T, root, clone *xmind.Topic, summaryTopicID string) {
+	t.Helper()
 	if clone.ID == root.ID {
 		t.Fatal("root id should change")
 	}
@@ -35,9 +34,17 @@ func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
 	if len(clone.Children.Summary) != 1 || clone.Children.Summary[0].ID == summaryTopicID {
 		t.Fatalf("summary topic id should change: %+v", clone.Children.Summary[0])
 	}
+}
+
+func assertDeepCloneBoundaries(t *testing.T, clone *xmind.Topic) {
+	t.Helper()
 	if clone.Boundaries[0].ID == "bound-old" || clone.Boundaries[0].Range != "(0,0)" {
 		t.Fatalf("boundary: want new id and preserved range, got %+v", clone.Boundaries[0])
 	}
+}
+
+func assertDeepCloneSummaryDescriptors(t *testing.T, clone *xmind.Topic) {
+	t.Helper()
 	if clone.Summaries[0].ID == "sum-old" {
 		t.Fatal("summary descriptor id should change")
 	}
@@ -48,6 +55,18 @@ func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
 	if clone.Summaries[0].Range != "(0,1)" {
 		t.Fatalf("summary range should be preserved, got %q", clone.Summaries[0].Range)
 	}
+}
+
+func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
+	summaryTopicID := uuid.New().String()
+	root := deepCloneFixtureTopic(summaryTopicID)
+	clone, err := deepCloneTopic(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDeepCloneRootAndAttached(t, root, &clone, summaryTopicID)
+	assertDeepCloneBoundaries(t, &clone)
+	assertDeepCloneSummaryDescriptors(t, &clone)
 }
 
 func TestAncestryPathHelper(t *testing.T) {

--- a/internal/server/handler/integration_test.go
+++ b/internal/server/handler/integration_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/mab-go/xmind-mcp/internal/xmind"
 )
 
+func matchIDForTitle(matches []searchTopicItem, title string) string {
+	for i := range matches {
+		if matches[i].Title == title {
+			return matches[i].ID
+		}
+	}
+	return ""
+}
+
 func TestIntegration_FindThenMutate(t *testing.T) {
 	h := NewXMindHandler()
 	path := copyFixture(t, kitchenSinkPath(t))
@@ -27,13 +36,7 @@ func TestIntegration_FindThenMutate(t *testing.T) {
 	if err := json.Unmarshal([]byte(textContent(t, res)), &st); err != nil {
 		t.Fatal(err)
 	}
-	var alphaID string
-	for i := range st.Matches {
-		if st.Matches[i].Title == "Alpha" {
-			alphaID = st.Matches[i].ID
-			break
-		}
-	}
+	alphaID := matchIDForTitle(st.Matches, "Alpha")
 	if alphaID == "" {
 		t.Fatal("Alpha not found")
 	}
@@ -56,6 +59,30 @@ func TestIntegration_FindThenMutate(t *testing.T) {
 	})
 	if findRes.IsError {
 		t.Fatal(textContent(t, findRes))
+	}
+}
+
+func attachedIDsByTitle(root *xmind.Topic, titles ...string) map[string]string {
+	out := make(map[string]string)
+	if root.Children == nil {
+		return out
+	}
+	for _, ch := range root.Children.Attached {
+		for _, want := range titles {
+			if ch.Title == want {
+				out[want] = ch.ID
+			}
+		}
+	}
+	return out
+}
+
+func assertOutlineContainsAll(t *testing.T, outline string, parts []string) {
+	t.Helper()
+	for _, s := range parts {
+		if !strings.Contains(outline, s) {
+			t.Fatalf("outline missing %q:\n%s", s, outline)
+		}
 	}
 }
 
@@ -88,20 +115,12 @@ func TestIntegration_BuildFromScratch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var idOne, idTwo string
-	for _, ch := range sheets[0].RootTopic.Children.Attached {
-		switch ch.Title {
-		case "One":
-			idOne = ch.ID
-		case "Two":
-			idTwo = ch.ID
-		}
-	}
-	if idOne == "" || idTwo == "" {
+	ids := attachedIDsByTitle(&sheets[0].RootTopic, "One", "Two")
+	if ids["One"] == "" || ids["Two"] == "" {
 		t.Fatalf("could not find One/Two: %+v", sheets[0].RootTopic.Children)
 	}
 	res := callTool(t, h.AddRelationship, map[string]any{
-		"path": path, "sheet_id": sid, "from_id": idOne, "to_id": idTwo, "label": "relates",
+		"path": path, "sheet_id": sid, "from_id": ids["One"], "to_id": ids["Two"], "label": "relates",
 	})
 	if res.IsError {
 		t.Fatal(textContent(t, res))
@@ -113,17 +132,30 @@ func TestIntegration_BuildFromScratch(t *testing.T) {
 		t.Fatal(textContent(t, flatRes))
 	}
 	out := textContent(t, flatRes)
-	for _, s := range []string{"Root", "One", "Two", "Three", "BulkRoot", "BulkChild"} {
-		if !strings.Contains(out, s) {
-			t.Fatalf("outline missing %q:\n%s", s, out)
-		}
-	}
+	assertOutlineContainsAll(t, out, []string{"Root", "One", "Two", "Three", "BulkRoot", "BulkChild"})
 	sheets, err = xmind.ReadMap(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(sheets[0].Relationships) < 1 {
 		t.Fatalf("expected relationship, got %+v", sheets[0].Relationships)
+	}
+}
+
+func sheetRootTitles(sheets []xmind.Sheet) []string {
+	out := make([]string, len(sheets))
+	for i := range sheets {
+		out[i] = sheets[i].RootTopic.Title
+	}
+	return out
+}
+
+func assertSheets1To14RootsUnchanged(t *testing.T, sheetsAfter []xmind.Sheet, wantRoots []string) {
+	t.Helper()
+	for i := 1; i < 15; i++ {
+		if got := sheetsAfter[i].RootTopic.Title; got != wantRoots[i] {
+			t.Fatalf("sheet %d root title changed: got %q want %q", i, got, wantRoots[i])
+		}
 	}
 }
 
@@ -137,10 +169,7 @@ func TestIntegration_KitchenSinkPreservation(t *testing.T) {
 	if len(sheetsBefore) != 15 {
 		t.Fatalf("want 15 sheets, got %d", len(sheetsBefore))
 	}
-	wantRoots := make([]string, 15)
-	for i := range sheetsBefore {
-		wantRoots[i] = sheetsBefore[i].RootTopic.Title
-	}
+	wantRoots := sheetRootTitles(sheetsBefore)
 	sid := sheetsBefore[0].ID
 	res := callTool(t, h.RenameTopic, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": kitchenSinkAlphaTopicID, "title": "AlphaTouched",
@@ -155,14 +184,26 @@ func TestIntegration_KitchenSinkPreservation(t *testing.T) {
 	if len(sheetsAfter) != 15 {
 		t.Fatalf("want 15 sheets after mutation, got %d", len(sheetsAfter))
 	}
-	for i := 1; i < 15; i++ {
-		if got := sheetsAfter[i].RootTopic.Title; got != wantRoots[i] {
-			t.Fatalf("sheet %d root title changed: got %q want %q", i, got, wantRoots[i])
-		}
-	}
+	assertSheets1To14RootsUnchanged(t, sheetsAfter, wantRoots)
 	topic := findTopicByID(&sheetsAfter[0].RootTopic, kitchenSinkAlphaTopicID)
 	if topic == nil || topic.Title != "AlphaTouched" {
 		t.Fatalf("expected mutation on sheet 0 only: %+v", topic)
+	}
+}
+
+func assertTopicTitleNotesLabels(t *testing.T, topic *xmind.Topic, wantTitle, wantNote string) {
+	t.Helper()
+	if topic == nil {
+		t.Fatal("topic missing")
+	}
+	if topic.Title != wantTitle {
+		t.Fatalf("title: got %q", topic.Title)
+	}
+	if topic.Notes == nil || topic.Notes.Plain == nil || topic.Notes.Plain.Content != wantNote {
+		t.Fatalf("notes: %+v", topic.Notes)
+	}
+	if len(topic.Labels) != 2 || topic.Labels[0] != "🏷️" {
+		t.Fatalf("labels: %v", topic.Labels)
 	}
 }
 
@@ -198,18 +239,7 @@ func TestEdgeCase_UnicodeContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	topic := findTopicByID(&sheets[0].RootTopic, tid)
-	if topic == nil {
-		t.Fatal("topic missing")
-	}
-	if topic.Title != title {
-		t.Fatalf("title: got %q", topic.Title)
-	}
-	if topic.Notes == nil || topic.Notes.Plain == nil || topic.Notes.Plain.Content != note {
-		t.Fatalf("notes: %+v", topic.Notes)
-	}
-	if len(topic.Labels) != 2 || topic.Labels[0] != "🏷️" {
-		t.Fatalf("labels: %v", topic.Labels)
-	}
+	assertTopicTitleNotesLabels(t, topic, title, note)
 }
 
 func TestEdgeCase_FloatingOnlySheet(t *testing.T) {

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -87,6 +87,43 @@ func buildTopicsFromArgs(raw []any) ([]xmind.Topic, int, *mcp.CallToolResult, er
 	return out, total, nil, nil
 }
 
+func topicFromBulkArgMap(m map[string]any, index int, depth int, total *int) (xmind.Topic, *mcp.CallToolResult, error) {
+	titleVal, ok := m["title"]
+	if !ok {
+		return xmind.Topic{}, nil, fmt.Errorf("topics[%d]: missing title", index)
+	}
+	title, ok := titleVal.(string)
+	if !ok {
+		return xmind.Topic{}, nil, fmt.Errorf("topics[%d]: title must be a string", index)
+	}
+	if *total >= maxBulkTopicsTotal {
+		return xmind.Topic{}, nil, fmt.Errorf("maximum topic count is %d", maxBulkTopicsTotal)
+	}
+	topic := xmind.Topic{
+		ID:    uuid.New().String(),
+		Title: title,
+	}
+	*total++
+	if ch, has := m["children"]; has && ch != nil {
+		arr, ok := ch.([]any)
+		if !ok {
+			return xmind.Topic{}, nil, fmt.Errorf("topics[%d]: children must be an array", index)
+		}
+		children, toolErr, err := buildTopicsFromArgsDepth(arr, depth+1, total)
+		if toolErr != nil {
+			return xmind.Topic{}, toolErr, nil
+		}
+		if err != nil {
+			return xmind.Topic{}, nil, err
+		}
+		topic.Children = &xmind.Children{Attached: children}
+	}
+	if toolResult := applyTopicPropertiesArgs(m, &topic); toolResult != nil {
+		return xmind.Topic{}, toolResult, nil
+	}
+	return topic, nil, nil
+}
+
 func buildTopicsFromArgsDepth(raw []any, depth int, total *int) ([]xmind.Topic, *mcp.CallToolResult, error) {
 	if depth > maxBulkTopicsDepth {
 		return nil, nil, fmt.Errorf("maximum nesting depth is %d", maxBulkTopicsDepth)
@@ -97,38 +134,12 @@ func buildTopicsFromArgsDepth(raw []any, depth int, total *int) ([]xmind.Topic, 
 		if !ok {
 			return nil, nil, fmt.Errorf("topics[%d]: expected object", i)
 		}
-		titleVal, ok := m["title"]
-		if !ok {
-			return nil, nil, fmt.Errorf("topics[%d]: missing title", i)
+		topic, toolRes, err := topicFromBulkArgMap(m, i, depth, total)
+		if toolRes != nil {
+			return nil, toolRes, nil
 		}
-		title, ok := titleVal.(string)
-		if !ok {
-			return nil, nil, fmt.Errorf("topics[%d]: title must be a string", i)
-		}
-		if *total >= maxBulkTopicsTotal {
-			return nil, nil, fmt.Errorf("maximum topic count is %d", maxBulkTopicsTotal)
-		}
-		topic := xmind.Topic{
-			ID:    uuid.New().String(),
-			Title: title,
-		}
-		*total++
-		if ch, has := m["children"]; has && ch != nil {
-			arr, ok := ch.([]any)
-			if !ok {
-				return nil, nil, fmt.Errorf("topics[%d]: children must be an array", i)
-			}
-			children, toolErr, err := buildTopicsFromArgsDepth(arr, depth+1, total)
-			if toolErr != nil {
-				return nil, toolErr, nil
-			}
-			if err != nil {
-				return nil, nil, err
-			}
-			topic.Children = &xmind.Children{Attached: children}
-		}
-		if toolResult := applyTopicPropertiesArgs(m, &topic); toolResult != nil {
-			return nil, toolResult, nil
+		if err != nil {
+			return nil, nil, err
 		}
 		out = append(out, topic)
 	}
@@ -158,6 +169,38 @@ func parseSummaryRange(r string) (from, to int, ok bool) {
 
 func formatSummaryRange(from, to int) string {
 	return fmt.Sprintf("(%d,%d)", from, to)
+}
+
+func validateAddSummary(parent *xmind.Topic, fromIdx, toIdx int) *mcp.CallToolResult {
+	if parent.Children == nil || len(parent.Children.Attached) == 0 {
+		return mcp.NewToolResultError("parent has no attached children to summarize")
+	}
+	n := len(parent.Children.Attached)
+	if fromIdx > toIdx {
+		return mcp.NewToolResultError("invalid summary range: from_index must be <= to_index")
+	}
+	if toIdx >= n {
+		return mcp.NewToolResultError(fmt.Sprintf("to_index %d is out of range for %d attached children", toIdx, n))
+	}
+	return nil
+}
+
+// applyAddSummary appends the summary topic and range descriptor (double-write per XMind schema).
+func applyAddSummary(parent *xmind.Topic, fromIdx, toIdx int, title string) string {
+	summaryTopicID := uuid.New().String()
+	summaryRowID := uuid.New().String()
+	summaryTopic := xmind.Topic{
+		ID:    summaryTopicID,
+		Title: title,
+	}
+	ch := ensureChildren(parent)
+	ch.Summary = append(ch.Summary, summaryTopic)
+	parent.Summaries = append(parent.Summaries, xmind.Summary{
+		ID:      summaryRowID,
+		Range:   formatSummaryRange(fromIdx, toIdx),
+		TopicID: summaryTopicID,
+	})
+	return summaryTopicID
 }
 
 // shiftSummaryRangesAfterRemove returns updated summary descriptors and topic IDs whose summary
@@ -321,6 +364,23 @@ func insertAttached(parent *xmind.Topic, topic xmind.Topic, pos *int) *mcp.CallT
 	return nil
 }
 
+// insertAttachedWithSummaryAdjust runs insertAttached, derives the insert index, and adjusts
+// existing summary ranges when the parent has summaries.
+func insertAttachedWithSummaryAdjust(parent *xmind.Topic, topic xmind.Topic, pos *int) (insertIdx int, toolErr *mcp.CallToolResult) {
+	if terr := insertAttached(parent, topic, pos); terr != nil {
+		return 0, terr
+	}
+	if pos == nil {
+		insertIdx = len(parent.Children.Attached) - 1
+	} else {
+		insertIdx = *pos
+	}
+	if len(parent.Summaries) > 0 {
+		adjustSummariesAfterAttachedInsert(parent, insertIdx)
+	}
+	return insertIdx, nil
+}
+
 func removeAttachedChild(parent *xmind.Topic, idx int) (*xmind.Topic, *mcp.CallToolResult) {
 	if idx < 0 || idx >= len(parent.Children.Attached) {
 		return nil, mcp.NewToolResultError("internal error: attached child index out of range")
@@ -385,37 +445,22 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 	if toolErr != nil {
 		return toolErr, nil
 	}
-	sheetID, terr := requireString(args, "sheet_id")
+	parts, terr := requireMapStrings(args, []string{"sheet_id", "parent_id", "title"})
 	if terr != nil {
 		return terr, nil
 	}
-	parentID, terr := requireString(args, "parent_id")
-	if terr != nil {
-		return terr, nil
-	}
-	title, terr := requireString(args, "title")
-	if terr != nil {
-		return terr, nil
-	}
+	sheetID, parentID, title := parts[0], parts[1], parts[2]
 	pos, perr := parsePositionOptional(args["position"])
 	if perr != nil {
 		return perr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
-	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	parent := findTopicByID(&sh.RootTopic, parentID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
+	if mapErr != nil {
+		return mapErr, nil
 	}
 
 	topic := xmind.Topic{
@@ -425,17 +470,9 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 	if toolResult := applyTopicPropertiesArgs(args, &topic); toolResult != nil {
 		return toolResult, nil
 	}
-	if terr := insertAttached(parent, topic, pos); terr != nil {
+	insertIdx, terr := insertAttachedWithSummaryAdjust(parent, topic, pos)
+	if terr != nil {
 		return terr, nil
-	}
-	insertIdx := 0
-	if pos == nil {
-		insertIdx = len(parent.Children.Attached) - 1
-	} else {
-		insertIdx = *pos
-	}
-	if len(parent.Summaries) > 0 {
-		adjustSummariesAfterAttachedInsert(parent, insertIdx)
 	}
 	sh.RevisionID = uuid.New().String()
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
@@ -456,41 +493,26 @@ func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolReque
 	if toolErr != nil {
 		return toolErr, nil
 	}
-	sheetID, terr := requireString(args, "sheet_id")
+	parts, terr := requireMapStrings(args, []string{"sheet_id", "topic_id", "target_parent_id"})
 	if terr != nil {
 		return terr, nil
 	}
-	topicID, terr := requireString(args, "topic_id")
-	if terr != nil {
-		return terr, nil
-	}
-	targetParentID, terr := requireString(args, "target_parent_id")
-	if terr != nil {
-		return terr, nil
-	}
+	sheetID, topicID, targetParentID := parts[0], parts[1], parts[2]
 	pos, perr := parsePositionOptional(args["position"])
 	if perr != nil {
 		return perr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, tErr, err := loadSheetByID(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
+	if tErr != nil {
+		return tErr, nil
 	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	source := findTopicByID(&sh.RootTopic, topicID)
-	if source == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("source topic not found: %s", topicID)), nil
-	}
-	targetParent := findTopicByID(&sh.RootTopic, targetParentID)
-	if targetParent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("target parent not found: %s", targetParentID)), nil
+	source, targetParent, rerr := resolveDuplicateTopicPair(&sh.RootTopic, topicID, targetParentID)
+	if rerr != nil {
+		return rerr, nil
 	}
 
 	clone, err := deepCloneTopic(source)
@@ -500,17 +522,9 @@ func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolReque
 	newRootID := clone.ID
 	n := countTopics(&clone)
 
-	if terr := insertAttached(targetParent, clone, pos); terr != nil {
+	insertIdx, terr := insertAttachedWithSummaryAdjust(targetParent, clone, pos)
+	if terr != nil {
 		return terr, nil
-	}
-	insertIdx := 0
-	if pos == nil {
-		insertIdx = len(targetParent.Children.Attached) - 1
-	} else {
-		insertIdx = *pos
-	}
-	if len(targetParent.Summaries) > 0 {
-		adjustSummariesAfterAttachedInsert(targetParent, insertIdx)
 	}
 	sh.RevisionID = uuid.New().String()
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
@@ -534,17 +548,14 @@ func (h *XMindHandler) AddTopicsBulk(ctx context.Context, req mcp.CallToolReques
 	if toolErr != nil {
 		return toolErr, nil
 	}
-	sheetID, terr := requireString(args, "sheet_id")
+	parts, terr := requireMapStrings(args, []string{"sheet_id", "parent_id"})
 	if terr != nil {
 		return terr, nil
 	}
-	parentID, terr := requireString(args, "parent_id")
-	if terr != nil {
-		return terr, nil
-	}
-	rawTopics, ok := args["topics"].([]any)
-	if !ok || rawTopics == nil {
-		return mcp.NewToolResultError("missing or invalid argument: topics (expected array)"), nil
+	sheetID, parentID := parts[0], parts[1]
+	rawTopics, aerr := parseBulkTopicsArray(args)
+	if aerr != nil {
+		return aerr, nil
 	}
 
 	topics, count, topicsToolErr, perr := buildTopicsFromArgs(rawTopics)
@@ -555,20 +566,12 @@ func (h *XMindHandler) AddTopicsBulk(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError("invalid argument topics: " + perr.Error()), nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
-	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	parent := findTopicByID(&sh.RootTopic, parentID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
+	if mapErr != nil {
+		return mapErr, nil
 	}
 
 	ch := ensureChildren(parent)
@@ -1176,6 +1179,70 @@ func loadSheetByID(absPath, sheetID string) ([]xmind.Sheet, *xmind.Sheet, *mcp.C
 	return sheets, sh, nil, nil
 }
 
+// loadSheetAndParentTopic loads the map and resolves parentID under the sheet root.
+func loadSheetAndParentTopic(absPath, sheetID, parentID string) ([]xmind.Sheet, *xmind.Sheet, *xmind.Topic, *mcp.CallToolResult, error) {
+	sheets, sh, tErr, err := loadSheetByID(absPath, sheetID)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if tErr != nil {
+		return nil, nil, nil, tErr, nil
+	}
+	parent := findTopicByID(&sh.RootTopic, parentID)
+	if parent == nil {
+		return sheets, sh, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
+	}
+	return sheets, sh, parent, nil, nil
+}
+
+func parseBulkTopicsArray(args map[string]any) ([]any, *mcp.CallToolResult) {
+	rawTopics, ok := args["topics"].([]any)
+	if !ok || rawTopics == nil {
+		return nil, mcp.NewToolResultError("missing or invalid argument: topics (expected array)")
+	}
+	return rawTopics, nil
+}
+
+func requireRelationshipEndpoints(root *xmind.Topic, fromID, toID string) *mcp.CallToolResult {
+	if findTopicByID(root, fromID) == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", fromID))
+	}
+	if findTopicByID(root, toID) == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", toID))
+	}
+	return nil
+}
+
+func appendRelationship(sh *xmind.Sheet, fromID, toID, label string) string {
+	relID := uuid.New().String()
+	sh.Relationships = append(sh.Relationships, xmind.Relationship{
+		ID:     relID,
+		End1ID: fromID,
+		End2ID: toID,
+		Title:  label,
+	})
+	return relID
+}
+
+func validateParentHasAttachedForBoundary(parent *xmind.Topic) *mcp.CallToolResult {
+	if parent.Children == nil || len(parent.Children.Attached) == 0 {
+		return mcp.NewToolResultError("parent has no attached children for a boundary")
+	}
+	return nil
+}
+
+func resolveDuplicateTopicPair(root *xmind.Topic, topicID, targetParentID string) (*xmind.Topic, *xmind.Topic, *mcp.CallToolResult) {
+	source := findTopicByID(root, topicID)
+	if source == nil {
+		return nil, nil, mcp.NewToolResultError(fmt.Sprintf("source topic not found: %s", topicID))
+	}
+	targetParent := findTopicByID(root, targetParentID)
+	if targetParent == nil {
+		return nil, nil, mcp.NewToolResultError(fmt.Sprintf("target parent not found: %s", targetParentID))
+	}
+	return source, targetParent, nil
+}
+
 func applyTopicPropertiesToTopics(args map[string]any, topics []*xmind.Topic) *mcp.CallToolResult {
 	for _, topic := range topics {
 		if r := applyTopicPropertiesArgs(args, topic); r != nil {
@@ -1342,41 +1409,23 @@ func (h *XMindHandler) AddRelationship(ctx context.Context, req mcp.CallToolRequ
 	if terr != nil {
 		return terr, nil
 	}
-	var label string
-	if v, has := args["label"]; has && v != nil {
-		s, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument label: expected a string"), nil
-		}
-		label = s
+	label, oerr := optionalStringArg(args, "label")
+	if oerr != nil {
+		return oerr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, tErr, err := loadSheetByID(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
+	if tErr != nil {
+		return tErr, nil
 	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	if findTopicByID(&sh.RootTopic, fromID) == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", fromID)), nil
-	}
-	if findTopicByID(&sh.RootTopic, toID) == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", toID)), nil
+	if e := requireRelationshipEndpoints(&sh.RootTopic, fromID, toID); e != nil {
+		return e, nil
 	}
 
-	relID := uuid.New().String()
-	rel := xmind.Relationship{
-		ID:     relID,
-		End1ID: fromID,
-		End2ID: toID,
-		Title:  label,
-	}
-	sh.Relationships = append(sh.Relationships, rel)
+	relID := appendRelationship(sh, fromID, toID, label)
 	sh.RevisionID = uuid.New().String()
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
@@ -1433,14 +1482,11 @@ func (h *XMindHandler) AddSummary(ctx context.Context, req mcp.CallToolRequest) 
 	if toolErr != nil {
 		return toolErr, nil
 	}
-	sheetID, terr := requireString(args, "sheet_id")
+	parts, terr := requireMapStrings(args, []string{"sheet_id", "parent_id"})
 	if terr != nil {
 		return terr, nil
 	}
-	parentID, terr := requireString(args, "parent_id")
-	if terr != nil {
-		return terr, nil
-	}
+	sheetID, parentID := parts[0], parts[1]
 	fromIdx, terr := requireNonNegativeInt(args, "from_index")
 	if terr != nil {
 		return terr, nil
@@ -1449,54 +1495,23 @@ func (h *XMindHandler) AddSummary(ctx context.Context, req mcp.CallToolRequest) 
 	if terr != nil {
 		return terr, nil
 	}
-	var title string
-	if v, has := args["title"]; has && v != nil {
-		s, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument title: expected a string"), nil
-		}
-		title = s
+	title, oerr := optionalStringArg(args, "title")
+	if oerr != nil {
+		return oerr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
+	if mapErr != nil {
+		return mapErr, nil
 	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	parent := findTopicByID(&sh.RootTopic, parentID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
-	}
-	if parent.Children == nil || len(parent.Children.Attached) == 0 {
-		return mcp.NewToolResultError("parent has no attached children to summarize"), nil
-	}
-	n := len(parent.Children.Attached)
-	if fromIdx > toIdx {
-		return mcp.NewToolResultError("invalid summary range: from_index must be <= to_index"), nil
-	}
-	if toIdx >= n {
-		return mcp.NewToolResultError(fmt.Sprintf("to_index %d is out of range for %d attached children", toIdx, n)), nil
+	if verr := validateAddSummary(parent, fromIdx, toIdx); verr != nil {
+		return verr, nil
 	}
 
-	summaryTopicID := uuid.New().String()
-	summaryRowID := uuid.New().String()
-	summaryTopic := xmind.Topic{
-		ID:    summaryTopicID,
-		Title: title,
-	}
-	ch := ensureChildren(parent)
-	ch.Summary = append(ch.Summary, summaryTopic)
-	parent.Summaries = append(parent.Summaries, xmind.Summary{
-		ID:      summaryRowID,
-		Range:   formatSummaryRange(fromIdx, toIdx),
-		TopicID: summaryTopicID,
-	})
+	summaryTopicID := applyAddSummary(parent, fromIdx, toIdx, title)
 
 	sh.RevisionID = uuid.New().String()
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
@@ -1521,32 +1536,20 @@ func (h *XMindHandler) AddBoundary(ctx context.Context, req mcp.CallToolRequest)
 	if terr != nil {
 		return terr, nil
 	}
-	var title string
-	if v, has := args["title"]; has && v != nil {
-		s, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument title: expected a string"), nil
-		}
-		title = s
+	title, oerr := optionalStringArg(args, "title")
+	if oerr != nil {
+		return oerr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
+	if mapErr != nil {
+		return mapErr, nil
 	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	parent := findTopicByID(&sh.RootTopic, parentID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
-	}
-	if parent.Children == nil || len(parent.Children.Attached) == 0 {
-		return mcp.NewToolResultError("parent has no attached children for a boundary"), nil
+	if verr := validateParentHasAttachedForBoundary(parent); verr != nil {
+		return verr, nil
 	}
 
 	boundaryID := uuid.New().String()
@@ -1562,6 +1565,19 @@ func (h *XMindHandler) AddBoundary(ctx context.Context, req mcp.CallToolRequest)
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("added boundary id %s", boundaryID)), nil
+}
+
+// optionalStringArg returns ("", nil) when key is absent or null; on wrong type returns a tool error.
+func optionalStringArg(args map[string]any, key string) (string, *mcp.CallToolResult) {
+	v, has := args[key]
+	if !has || v == nil {
+		return "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", mcp.NewToolResultError(fmt.Sprintf("invalid argument %s: expected a string", key))
+	}
+	return s, nil
 }
 
 func requireNonNegativeInt(args map[string]any, key string) (int, *mcp.CallToolResult) {
@@ -1603,4 +1619,17 @@ func requireString(args map[string]any, key string) (string, *mcp.CallToolResult
 		return "", mcp.NewToolResultError("invalid argument " + key + ": expected a non-empty string")
 	}
 	return s, nil
+}
+
+// requireMapStrings returns requireString values for keys in order.
+func requireMapStrings(args map[string]any, keys []string) ([]string, *mcp.CallToolResult) {
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		s, err := requireString(args, k)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = s
+	}
+	return out, nil
 }

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -160,16 +160,13 @@ func formatSummaryRange(from, to int) string {
 	return fmt.Sprintf("(%d,%d)", from, to)
 }
 
-// adjustSummariesAfterAttachedRemove updates parent.Summaries and Children.Summary after
-// removing the attached child at removedIndex.
-func adjustSummariesAfterAttachedRemove(parent *xmind.Topic, removedIndex int) {
-	if parent == nil || parent.Children == nil {
-		return
-	}
+// shiftSummaryRangesAfterRemove returns updated summary descriptors and topic IDs whose summary
+// children should be removed after deleting the attached child at removedIndex.
+func shiftSummaryRangesAfterRemove(summaries []xmind.Summary, removedIndex int) ([]xmind.Summary, map[string]struct{}) {
 	N := removedIndex
 	removeTopicIDs := make(map[string]struct{})
 	var newSummaries []xmind.Summary
-	for _, s := range parent.Summaries {
+	for _, s := range summaries {
 		from, to, ok := parseSummaryRange(s.Range)
 		if !ok {
 			newSummaries = append(newSummaries, s)
@@ -189,6 +186,29 @@ func adjustSummariesAfterAttachedRemove(parent *xmind.Topic, removedIndex int) {
 		s.Range = formatSummaryRange(newFrom, newTo)
 		newSummaries = append(newSummaries, s)
 	}
+	return newSummaries, removeTopicIDs
+}
+
+func filterSummaryChildren(summaryChildren []xmind.Topic, removeIDs map[string]struct{}) []xmind.Topic {
+	if len(removeIDs) == 0 {
+		return summaryChildren
+	}
+	var kept []xmind.Topic
+	for i := range summaryChildren {
+		if _, drop := removeIDs[summaryChildren[i].ID]; !drop {
+			kept = append(kept, summaryChildren[i])
+		}
+	}
+	return kept
+}
+
+// adjustSummariesAfterAttachedRemove updates parent.Summaries and Children.Summary after
+// removing the attached child at removedIndex.
+func adjustSummariesAfterAttachedRemove(parent *xmind.Topic, removedIndex int) {
+	if parent == nil || parent.Children == nil {
+		return
+	}
+	newSummaries, removeTopicIDs := shiftSummaryRangesAfterRemove(parent.Summaries, removedIndex)
 	parent.Summaries = newSummaries
 	if len(parent.Summaries) == 0 {
 		parent.Summaries = nil
@@ -196,13 +216,7 @@ func adjustSummariesAfterAttachedRemove(parent *xmind.Topic, removedIndex int) {
 	if len(removeTopicIDs) == 0 {
 		return
 	}
-	var kept []xmind.Topic
-	for i := range parent.Children.Summary {
-		if _, drop := removeTopicIDs[parent.Children.Summary[i].ID]; !drop {
-			kept = append(kept, parent.Children.Summary[i])
-		}
-	}
-	parent.Children.Summary = kept
+	parent.Children.Summary = filterSummaryChildren(parent.Children.Summary, removeTopicIDs)
 	if len(parent.Children.Summary) == 0 {
 		parent.Children.Summary = nil
 	}
@@ -307,45 +321,57 @@ func insertAttached(parent *xmind.Topic, topic xmind.Topic, pos *int) *mcp.CallT
 	return nil
 }
 
+func removeAttachedChild(parent *xmind.Topic, idx int) (*xmind.Topic, *mcp.CallToolResult) {
+	if idx < 0 || idx >= len(parent.Children.Attached) {
+		return nil, mcp.NewToolResultError("internal error: attached child index out of range")
+	}
+	removed := parent.Children.Attached[idx]
+	parent.Children.Attached = slices.Delete(parent.Children.Attached, idx, idx+1)
+	if len(parent.Children.Attached) == 0 {
+		parent.Children.Attached = nil
+	}
+	adjustSummariesAfterAttachedRemove(parent, idx)
+	nilEmptyChildren(parent)
+	return &removed, nil
+}
+
+func removeDetachedChild(parent *xmind.Topic, idx int) (*xmind.Topic, *mcp.CallToolResult) {
+	if idx < 0 || idx >= len(parent.Children.Detached) {
+		return nil, mcp.NewToolResultError("internal error: detached child index out of range")
+	}
+	removed := parent.Children.Detached[idx]
+	parent.Children.Detached = slices.Delete(parent.Children.Detached, idx, idx+1)
+	if len(parent.Children.Detached) == 0 {
+		parent.Children.Detached = nil
+	}
+	nilEmptyChildren(parent)
+	return &removed, nil
+}
+
+func removeSummaryChild(parent *xmind.Topic, idx int) (*xmind.Topic, *mcp.CallToolResult) {
+	if idx < 0 || idx >= len(parent.Children.Summary) {
+		return nil, mcp.NewToolResultError("internal error: summary child index out of range")
+	}
+	removed := parent.Children.Summary[idx]
+	parent.Children.Summary = slices.Delete(parent.Children.Summary, idx, idx+1)
+	if len(parent.Children.Summary) == 0 {
+		parent.Children.Summary = nil
+	}
+	nilEmptyChildren(parent)
+	return &removed, nil
+}
+
 func removeChildAt(parent *xmind.Topic, idx int, listType string) (*xmind.Topic, *mcp.CallToolResult) {
 	if parent == nil || parent.Children == nil {
 		return nil, mcp.NewToolResultError("internal error: parent has no children")
 	}
 	switch listType {
 	case "attached":
-		if idx < 0 || idx >= len(parent.Children.Attached) {
-			return nil, mcp.NewToolResultError("internal error: attached child index out of range")
-		}
-		removed := parent.Children.Attached[idx]
-		parent.Children.Attached = slices.Delete(parent.Children.Attached, idx, idx+1)
-		if len(parent.Children.Attached) == 0 {
-			parent.Children.Attached = nil
-		}
-		adjustSummariesAfterAttachedRemove(parent, idx)
-		nilEmptyChildren(parent)
-		return &removed, nil
+		return removeAttachedChild(parent, idx)
 	case "detached":
-		if idx < 0 || idx >= len(parent.Children.Detached) {
-			return nil, mcp.NewToolResultError("internal error: detached child index out of range")
-		}
-		removed := parent.Children.Detached[idx]
-		parent.Children.Detached = slices.Delete(parent.Children.Detached, idx, idx+1)
-		if len(parent.Children.Detached) == 0 {
-			parent.Children.Detached = nil
-		}
-		nilEmptyChildren(parent)
-		return &removed, nil
+		return removeDetachedChild(parent, idx)
 	case "summary":
-		if idx < 0 || idx >= len(parent.Children.Summary) {
-			return nil, mcp.NewToolResultError("internal error: summary child index out of range")
-		}
-		removed := parent.Children.Summary[idx]
-		parent.Children.Summary = slices.Delete(parent.Children.Summary, idx, idx+1)
-		if len(parent.Children.Summary) == 0 {
-			parent.Children.Summary = nil
-		}
-		nilEmptyChildren(parent)
-		return &removed, nil
+		return removeSummaryChild(parent, idx)
 	default:
 		return nil, mcp.NewToolResultError("internal error: unknown child list type")
 	}
@@ -611,6 +637,18 @@ func (h *XMindHandler) RenameTopic(ctx context.Context, req mcp.CallToolRequest)
 	return textResult(fmt.Sprintf("renamed topic %s", topicID)), nil
 }
 
+func deleteNonRootTopic(sh *xmind.Sheet, topicID string) *mcp.CallToolResult {
+	if topicID == sh.RootTopic.ID {
+		return mcp.NewToolResultError("cannot delete the root topic of a sheet")
+	}
+	parent, idx, listType := findParentOfTopic(&sh.RootTopic, topicID)
+	if parent == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID))
+	}
+	_, rerr := removeChildAt(parent, idx, listType)
+	return rerr
+}
+
 // DeleteTopic removes a topic and its subtree (not the sheet root).
 func (h *XMindHandler) DeleteTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
@@ -639,16 +677,7 @@ func (h *XMindHandler) DeleteTopic(ctx context.Context, req mcp.CallToolRequest)
 	if sh == nil {
 		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
-	if topicID == sh.RootTopic.ID {
-		return mcp.NewToolResultError("cannot delete the root topic of a sheet"), nil
-	}
-	parent, idx, listType := findParentOfTopic(&sh.RootTopic, topicID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
-	}
-
-	_, rerr := removeChildAt(parent, idx, listType)
-	if rerr != nil {
+	if rerr := deleteNonRootTopic(sh, topicID); rerr != nil {
 		return rerr, nil
 	}
 	sh.RevisionID = uuid.New().String()
@@ -658,92 +687,101 @@ func (h *XMindHandler) DeleteTopic(ctx context.Context, req mcp.CallToolRequest)
 	return textResult(fmt.Sprintf("deleted topic %s", topicID)), nil
 }
 
-// MoveTopic reparents a topic under new_parent_id.
-func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	_ = ctx
-	args := req.GetArguments()
-	absPath, toolErr := absPathFromArgs(args)
+func validateMoveTopicPreconditions(sh *xmind.Sheet, topicID, newParentID string, topic, _ *xmind.Topic) *mcp.CallToolResult {
+	if topicID == sh.RootTopic.ID {
+		return mcp.NewToolResultError("cannot move the root topic")
+	}
+	if isDescendantOf(topic, newParentID) {
+		return mcp.NewToolResultError("cannot move a topic into its own subtree")
+	}
+	return nil
+}
+
+func detachTopicFromTree(root *xmind.Topic, topicID string) (*xmind.Topic, *mcp.CallToolResult) {
+	parent, idx, listType := findParentOfTopic(root, topicID)
+	if parent == nil {
+		return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID))
+	}
+	return removeChildAt(parent, idx, listType)
+}
+
+// attachDetachedToParent re-resolves newParent after a remove (stale pointer if sibling in same Attached slice).
+func attachDetachedToParent(root *xmind.Topic, newParentID string, removed *xmind.Topic, pos *int) (insertIdx, siblingCount int, toolErr *mcp.CallToolResult) {
+	newParent := findTopicByID(root, newParentID)
+	if newParent == nil {
+		return 0, 0, mcp.NewToolResultError(fmt.Sprintf("new parent topic not found after remove: %s", newParentID))
+	}
+	if terr := insertAttached(newParent, *removed, pos); terr != nil {
+		return 0, 0, terr
+	}
+	if pos == nil {
+		insertIdx = len(newParent.Children.Attached) - 1
+	} else {
+		insertIdx = *pos
+	}
+	if len(newParent.Summaries) > 0 {
+		adjustSummariesAfterAttachedInsert(newParent, insertIdx)
+	}
+	return insertIdx, len(newParent.Children.Attached), nil
+}
+
+func moveTopicFromArgs(args map[string]any) (absPath, sheetID, topicID, newParentID string, pos *int, toolErr *mcp.CallToolResult) {
+	absPath, toolErr = absPathFromArgs(args)
 	if toolErr != nil {
-		return toolErr, nil
+		return "", "", "", "", nil, toolErr
 	}
-	sheetID, terr := requireString(args, "sheet_id")
-	if terr != nil {
-		return terr, nil
+	sheetID, toolErr = requireString(args, "sheet_id")
+	if toolErr != nil {
+		return absPath, "", "", "", nil, toolErr
 	}
-	topicID, terr := requireString(args, "topic_id")
-	if terr != nil {
-		return terr, nil
+	topicID, toolErr = requireString(args, "topic_id")
+	if toolErr != nil {
+		return absPath, sheetID, "", "", nil, toolErr
 	}
-	newParentID, terr := requireString(args, "new_parent_id")
-	if terr != nil {
-		return terr, nil
+	newParentID, toolErr = requireString(args, "new_parent_id")
+	if toolErr != nil {
+		return absPath, sheetID, topicID, "", nil, toolErr
 	}
 	pos, perr := parsePositionOptional(args["position"])
 	if perr != nil {
-		return perr, nil
+		return absPath, sheetID, topicID, newParentID, nil, perr
+	}
+	return absPath, sheetID, topicID, newParentID, pos, nil
+}
+
+// MoveTopic reparents a topic under new_parent_id.
+func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	absPath, sheetID, topicID, newParentID, pos, aerr := moveTopicFromArgs(req.GetArguments())
+	if aerr != nil {
+		return aerr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, topic, newParent, ctxErr, err := loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
+	if ctxErr != nil {
+		return ctxErr, nil
 	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	topic := findTopicByID(&sh.RootTopic, topicID)
-	if topic == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
-	}
-	if topicID == sh.RootTopic.ID {
-		return mcp.NewToolResultError("cannot move the root topic"), nil
-	}
-	newParent := findTopicByID(&sh.RootTopic, newParentID)
-	if newParent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", newParentID)), nil
-	}
-	if isDescendantOf(topic, newParentID) {
-		return mcp.NewToolResultError("cannot move a topic into its own subtree"), nil
+	if terr := validateMoveTopicPreconditions(sh, topicID, newParentID, topic, newParent); terr != nil {
+		return terr, nil
 	}
 
-	parent, idx, listType := findParentOfTopic(&sh.RootTopic, topicID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
-	}
-
-	removed, rerr := removeChildAt(parent, idx, listType)
+	removed, rerr := detachTopicFromTree(&sh.RootTopic, topicID)
 	if rerr != nil {
 		return rerr, nil
 	}
 
-	// Re-resolve newParent after the slice mutation: the pointer obtained before
-	// removeChildAt may be stale if newParent was a sibling of the removed topic
-	// in the same Attached slice (slices.Delete shifts elements in place).
-	newParent = findTopicByID(&sh.RootTopic, newParentID)
-	if newParent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("new parent topic not found after remove: %s", newParentID)), nil
+	moveInsertIdx, n, aerr := attachDetachedToParent(&sh.RootTopic, newParentID, removed, pos)
+	if aerr != nil {
+		return aerr, nil
 	}
 
-	if terr := insertAttached(newParent, *removed, pos); terr != nil {
-		return terr, nil
-	}
-	moveInsertIdx := 0
-	if pos == nil {
-		moveInsertIdx = len(newParent.Children.Attached) - 1
-	} else {
-		moveInsertIdx = *pos
-	}
-	if len(newParent.Summaries) > 0 {
-		adjustSummariesAfterAttachedInsert(newParent, moveInsertIdx)
-	}
 	sh.RevisionID = uuid.New().String()
 	if err := xmind.WriteMap(absPath, sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
-	n := len(newParent.Children.Attached)
 	return jsonResult(moveTopicResponse{
 		TopicID:      topicID,
 		ParentID:     newParentID,
@@ -752,57 +790,67 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 	})
 }
 
-// ReorderChildren reorders attached children of parent_id.
-func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	_ = ctx
-	args := req.GetArguments()
-	absPath, toolErr := absPathFromArgs(args)
-	if toolErr != nil {
-		return toolErr, nil
+func loadSheetParentTopic(absPath, sheetID, parentID string) ([]xmind.Sheet, *xmind.Sheet, *xmind.Topic, *mcp.CallToolResult, error) {
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
-	sheetID, terr := requireString(args, "sheet_id")
-	if terr != nil {
-		return terr, nil
+	if toolErr2 != nil {
+		return nil, nil, nil, toolErr2, nil
 	}
-	parentID, terr := requireString(args, "parent_id")
-	if terr != nil {
-		return terr, nil
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return sheets, nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
-	rawIDs, ok := args["ordered_ids"].([]any)
-	if !ok || rawIDs == nil {
-		return mcp.NewToolResultError("missing or invalid argument: ordered_ids (expected array)"), nil
+	parent := findTopicByID(&sh.RootTopic, parentID)
+	if parent == nil {
+		return sheets, sh, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
 	}
+	return sheets, sh, parent, nil, nil
+}
+
+func loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID string) ([]xmind.Sheet, *xmind.Sheet, *xmind.Topic, *xmind.Topic, *mcp.CallToolResult, error) {
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	if toolErr2 != nil {
+		return nil, nil, nil, nil, toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return sheets, nil, nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+	topic := findTopicByID(&sh.RootTopic, topicID)
+	if topic == nil {
+		return sheets, sh, nil, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
+	}
+	newParent := findTopicByID(&sh.RootTopic, newParentID)
+	if newParent == nil {
+		return sheets, sh, topic, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", newParentID)), nil
+	}
+	return sheets, sh, topic, newParent, nil, nil
+}
+
+func parseOrderedIDs(rawIDs []any) ([]string, *mcp.CallToolResult) {
 	orderedIDs := make([]string, 0, len(rawIDs))
 	for i, v := range rawIDs {
 		s, ok := v.(string)
 		if !ok || s == "" {
-			return mcp.NewToolResultError(fmt.Sprintf("ordered_ids[%d]: expected non-empty string", i)), nil
+			return nil, mcp.NewToolResultError(fmt.Sprintf("ordered_ids[%d]: expected non-empty string", i))
 		}
 		orderedIDs = append(orderedIDs, s)
 	}
+	return orderedIDs, nil
+}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
-	if err != nil {
-		return nil, err
-	}
-	if toolErr2 != nil {
-		return toolErr2, nil
-	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	parent := findTopicByID(&sh.RootTopic, parentID)
-	if parent == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
-	}
+func validateReorderAttached(parent *xmind.Topic, orderedIDs []string) ([]xmind.Topic, *mcp.CallToolResult) {
 	if parent.Children == nil || len(parent.Children.Attached) == 0 {
-		return mcp.NewToolResultError("parent has no attached children to reorder"), nil
+		return nil, mcp.NewToolResultError("parent has no attached children to reorder")
 	}
 	if len(orderedIDs) != len(parent.Children.Attached) {
-		return mcp.NewToolResultError(fmt.Sprintf("ordered_ids length %d does not match attached child count %d", len(orderedIDs), len(parent.Children.Attached))), nil
+		return nil, mcp.NewToolResultError(fmt.Sprintf("ordered_ids length %d does not match attached child count %d", len(orderedIDs), len(parent.Children.Attached)))
 	}
-
 	byID := make(map[string]xmind.Topic, len(parent.Children.Attached))
 	for _, t := range parent.Children.Attached {
 		byID[t.ID] = t
@@ -811,17 +859,63 @@ func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequ
 	newOrder := make([]xmind.Topic, 0, len(orderedIDs))
 	for _, id := range orderedIDs {
 		if _, dup := seen[id]; dup {
-			return mcp.NewToolResultError(fmt.Sprintf("duplicate id in ordered_ids: %s", id)), nil
+			return nil, mcp.NewToolResultError(fmt.Sprintf("duplicate id in ordered_ids: %s", id))
 		}
 		seen[id] = struct{}{}
 		t, ok := byID[id]
 		if !ok {
-			return mcp.NewToolResultError(fmt.Sprintf("ordered_ids contains unknown id: %s", id)), nil
+			return nil, mcp.NewToolResultError(fmt.Sprintf("ordered_ids contains unknown id: %s", id))
 		}
 		newOrder = append(newOrder, t)
 	}
 	if len(seen) != len(byID) {
-		return mcp.NewToolResultError("ordered_ids must list every attached child exactly once"), nil
+		return nil, mcp.NewToolResultError("ordered_ids must list every attached child exactly once")
+	}
+	return newOrder, nil
+}
+
+func reorderChildrenFromArgs(args map[string]any) (absPath, sheetID, parentID string, orderedIDs []string, toolErr *mcp.CallToolResult) {
+	absPath, toolErr = absPathFromArgs(args)
+	if toolErr != nil {
+		return "", "", "", nil, toolErr
+	}
+	sheetID, toolErr = requireString(args, "sheet_id")
+	if toolErr != nil {
+		return absPath, "", "", nil, toolErr
+	}
+	parentID, toolErr = requireString(args, "parent_id")
+	if toolErr != nil {
+		return absPath, sheetID, "", nil, toolErr
+	}
+	rawIDs, ok := args["ordered_ids"].([]any)
+	if !ok || rawIDs == nil {
+		return absPath, sheetID, parentID, nil, mcp.NewToolResultError("missing or invalid argument: ordered_ids (expected array)")
+	}
+	orderedIDs, oerr := parseOrderedIDs(rawIDs)
+	if oerr != nil {
+		return absPath, sheetID, parentID, nil, oerr
+	}
+	return absPath, sheetID, parentID, orderedIDs, nil
+}
+
+// ReorderChildren reorders attached children of parent_id.
+func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	absPath, sheetID, parentID, orderedIDs, aerr := reorderChildrenFromArgs(req.GetArguments())
+	if aerr != nil {
+		return aerr, nil
+	}
+
+	sheets, sh, parent, ctxErr, err := loadSheetParentTopic(absPath, sheetID, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if ctxErr != nil {
+		return ctxErr, nil
+	}
+	newOrder, verr := validateReorderAttached(parent, orderedIDs)
+	if verr != nil {
+		return verr, nil
 	}
 
 	parent.Children.Attached = newOrder

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -690,7 +690,7 @@ func (h *XMindHandler) DeleteTopic(ctx context.Context, req mcp.CallToolRequest)
 	return textResult(fmt.Sprintf("deleted topic %s", topicID)), nil
 }
 
-func validateMoveTopicPreconditions(sh *xmind.Sheet, topicID, newParentID string, topic, _ *xmind.Topic) *mcp.CallToolResult {
+func validateMoveTopicPreconditions(sh *xmind.Sheet, topicID, newParentID string, topic *xmind.Topic) *mcp.CallToolResult {
 	if topicID == sh.RootTopic.ID {
 		return mcp.NewToolResultError("cannot move the root topic")
 	}
@@ -760,14 +760,14 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 		return aerr, nil
 	}
 
-	sheets, sh, topic, newParent, ctxErr, err := loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID)
+	sheets, sh, topic, _, ctxErr, err := loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID)
 	if err != nil {
 		return nil, err
 	}
 	if ctxErr != nil {
 		return ctxErr, nil
 	}
-	if terr := validateMoveTopicPreconditions(sh, topicID, newParentID, topic, newParent); terr != nil {
+	if terr := validateMoveTopicPreconditions(sh, topicID, newParentID, topic); terr != nil {
 		return terr, nil
 	}
 

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -832,111 +832,261 @@ func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequ
 	return textResult(fmt.Sprintf("reordered %d children under %s", len(newOrder), parentID)), nil
 }
 
+func notesArgActionable(args map[string]any) bool {
+	_, has := args["notes"]
+	return has
+}
+
+func nonNilArgActionable(args map[string]any, key string) bool {
+	v, has := args[key]
+	return has && v != nil
+}
+
+func removeMarkersArgActionable(args map[string]any) bool {
+	v, has := args["remove_markers"]
+	if !has || v == nil {
+		return false
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return true
+	}
+	return len(arr) > 0
+}
+
 // hasActionableTopicPropertyArgs reports whether bulk set-topic-properties has at least one
 // property argument that would run a mutating branch (same rules as the single-topic tool).
+// Keep in sync with applyTopicPropertiesArgs: notes ⇒ key present; labels, markers, link ⇒ key present and value non-nil;
+// remove_markers ⇒ key present and non-nil, and (wrong type OR len(slice) > 0).
 func hasActionableTopicPropertyArgs(args map[string]any) bool {
-	if _, has := args["notes"]; has {
-		return true
+	return notesArgActionable(args) ||
+		nonNilArgActionable(args, "labels") ||
+		nonNilArgActionable(args, "markers") ||
+		nonNilArgActionable(args, "link") ||
+		removeMarkersArgActionable(args)
+}
+
+func applyNotesFromArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
+	v, has := args["notes"]
+	if !has {
+		return nil
 	}
-	if v, has := args["labels"]; has && v != nil {
-		return true
+	if v == nil {
+		topic.Notes = nil
+		return nil
 	}
-	if v, has := args["markers"]; has && v != nil {
-		return true
+	s, ok := v.(string)
+	if !ok {
+		return mcp.NewToolResultError("invalid argument notes: expected a string")
 	}
-	if v, has := args["link"]; has && v != nil {
-		return true
+	if s == "" {
+		topic.Notes = nil
+		return nil
 	}
-	if v, has := args["remove_markers"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return true // invalid type — apply will error
+	topic.Notes = &xmind.Notes{
+		Plain:    &xmind.NoteContent{Content: s},
+		RealHTML: &xmind.NoteContent{Content: plainToRealHTML(s)},
+	}
+	return nil
+}
+
+func applyLabelsFromArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
+	v, has := args["labels"]
+	if !has || v == nil {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return mcp.NewToolResultError("invalid argument labels: expected an array")
+	}
+	labels, err := stringSliceFromAnyArray(arr, "labels")
+	if err != nil {
+		return err
+	}
+	topic.Labels = labels
+	return nil
+}
+
+func applyMarkersFromArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
+	v, has := args["markers"]
+	if !has || v == nil {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return mcp.NewToolResultError("invalid argument markers: expected an array")
+	}
+	ss, err := stringSliceFromAnyArray(arr, "markers")
+	if err != nil {
+		return err
+	}
+	markers := make([]xmind.Marker, len(ss))
+	for i, s := range ss {
+		markers[i] = xmind.Marker{MarkerID: s}
+	}
+	topic.Markers = markers
+	return nil
+}
+
+func applyRemoveMarkersFromArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
+	v, has := args["remove_markers"]
+	if !has || v == nil {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return mcp.NewToolResultError("invalid argument remove_markers: expected an array")
+	}
+	if len(arr) == 0 {
+		return nil
+	}
+	remove, err := stringSetFromAnyArray(arr, "remove_markers")
+	if err != nil {
+		return err
+	}
+	out := make([]xmind.Marker, 0, len(topic.Markers))
+	for _, m := range topic.Markers {
+		if _, drop := remove[m.MarkerID]; !drop {
+			out = append(out, m)
 		}
-		return len(arr) > 0
 	}
-	return false
+	topic.Markers = out
+	return nil
+}
+
+func applyLinkFromArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
+	v, has := args["link"]
+	if !has || v == nil {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return mcp.NewToolResultError("invalid argument link: expected a string")
+	}
+	topic.Href = s
+	return nil
+}
+
+// stringSliceFromAnyArray parses arr into []string, using key as the argument name for errors ("labels[0]: …").
+func stringSliceFromAnyArray(arr []any, key string) ([]string, *mcp.CallToolResult) {
+	out := make([]string, 0, len(arr))
+	for i, el := range arr {
+		s, ok := el.(string)
+		if !ok {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d]: expected string", key, i))
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// stringSetFromAnyArray parses arr into a set of strings for remove_markers-style args.
+func stringSetFromAnyArray(arr []any, key string) (map[string]struct{}, *mcp.CallToolResult) {
+	remove := make(map[string]struct{}, len(arr))
+	for i, el := range arr {
+		s, ok := el.(string)
+		if !ok {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d]: expected string", key, i))
+		}
+		remove[s] = struct{}{}
+	}
+	return remove, nil
 }
 
 // applyTopicPropertiesArgs applies notes, labels, markers, remove_markers, and link from args
 // to topic using the same semantics as xmind_set_topic_properties.
 func applyTopicPropertiesArgs(args map[string]any, topic *xmind.Topic) *mcp.CallToolResult {
-	if v, has := args["notes"]; has {
-		if v == nil {
-			topic.Notes = nil
-		} else {
-			s, ok := v.(string)
-			if !ok {
-				return mcp.NewToolResultError("invalid argument notes: expected a string")
-			}
-			if s == "" {
-				topic.Notes = nil
-			} else {
-				topic.Notes = &xmind.Notes{
-					Plain:    &xmind.NoteContent{Content: s},
-					RealHTML: &xmind.NoteContent{Content: plainToRealHTML(s)},
-				}
-			}
-		}
+	if r := applyNotesFromArgs(args, topic); r != nil {
+		return r
 	}
-	if v, has := args["labels"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument labels: expected an array")
-		}
-		labels := make([]string, 0, len(arr))
-		for i, el := range arr {
-			s, ok := el.(string)
-			if !ok {
-				return mcp.NewToolResultError(fmt.Sprintf("labels[%d]: expected string", i))
-			}
-			labels = append(labels, s)
-		}
-		topic.Labels = labels
+	if r := applyLabelsFromArgs(args, topic); r != nil {
+		return r
 	}
-	if v, has := args["markers"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument markers: expected an array")
-		}
-		markers := make([]xmind.Marker, 0, len(arr))
-		for i, el := range arr {
-			s, ok := el.(string)
-			if !ok {
-				return mcp.NewToolResultError(fmt.Sprintf("markers[%d]: expected string", i))
-			}
-			markers = append(markers, xmind.Marker{MarkerID: s})
-		}
-		topic.Markers = markers
+	if r := applyMarkersFromArgs(args, topic); r != nil {
+		return r
 	}
-	if v, has := args["remove_markers"]; has && v != nil {
-		arr, ok := v.([]any)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument remove_markers: expected an array")
-		}
-		if len(arr) > 0 {
-			remove := make(map[string]struct{}, len(arr))
-			for i, el := range arr {
-				s, ok := el.(string)
-				if !ok {
-					return mcp.NewToolResultError(fmt.Sprintf("remove_markers[%d]: expected string", i))
-				}
-				remove[s] = struct{}{}
-			}
-			out := make([]xmind.Marker, 0, len(topic.Markers))
-			for _, m := range topic.Markers {
-				if _, drop := remove[m.MarkerID]; !drop {
-					out = append(out, m)
-				}
-			}
-			topic.Markers = out
-		}
+	if r := applyRemoveMarkersFromArgs(args, topic); r != nil {
+		return r
 	}
-	if v, has := args["link"]; has && v != nil {
+	if r := applyLinkFromArgs(args, topic); r != nil {
+		return r
+	}
+	return nil
+}
+
+// parseTopicIDsArgs validates args["topic_ids"] as a non-empty slice of unique non-empty strings.
+func parseTopicIDsArgs(args map[string]any) ([]string, *mcp.CallToolResult) {
+	raw, has := args["topic_ids"]
+	if !has {
+		return nil, mcp.NewToolResultError("missing required argument: topic_ids")
+	}
+	rawIDs, ok := raw.([]any)
+	if !ok {
+		return nil, mcp.NewToolResultError("invalid argument topic_ids: expected an array")
+	}
+	return collectUniqueTopicIDs(rawIDs)
+}
+
+func collectUniqueTopicIDs(rawIDs []any) ([]string, *mcp.CallToolResult) {
+	topicIDs := make([]string, 0, len(rawIDs))
+	seen := make(map[string]struct{}, len(rawIDs))
+	for i, v := range rawIDs {
 		s, ok := v.(string)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument link: expected a string")
+		if !ok || s == "" {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("topic_ids[%d]: expected non-empty string", i))
 		}
-		topic.Href = s
+		if _, dup := seen[s]; dup {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("duplicate id in topic_ids: %s", s))
+		}
+		seen[s] = struct{}{}
+		topicIDs = append(topicIDs, s)
+	}
+	if len(topicIDs) == 0 {
+		return nil, mcp.NewToolResultError("topic_ids must be non-empty")
+	}
+	return topicIDs, nil
+}
+
+// resolveTopicsForSheet returns pointers to topics for each id in order, or a tool error listing missing ids.
+func resolveTopicsForSheet(root *xmind.Topic, topicIDs []string) ([]*xmind.Topic, *mcp.CallToolResult) {
+	topics := make([]*xmind.Topic, 0, len(topicIDs))
+	missing := make([]string, 0)
+	for _, id := range topicIDs {
+		t := findTopicByID(root, id)
+		if t == nil {
+			missing = append(missing, id)
+		} else {
+			topics = append(topics, t)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", strings.Join(missing, ", ")))
+	}
+	return topics, nil
+}
+
+// loadSheetByID reads the map and returns the sheet with sheetID, or a tool/protocol error.
+func loadSheetByID(absPath, sheetID string) ([]xmind.Sheet, *xmind.Sheet, *mcp.CallToolResult, error) {
+	sheets, toolErr2, err := statAndReadMap(absPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if toolErr2 != nil {
+		return nil, nil, toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+	return sheets, sh, nil, nil
+}
+
+func applyTopicPropertiesToTopics(args map[string]any, topics []*xmind.Topic) *mcp.CallToolResult {
+	for _, topic := range topics {
+		if r := applyTopicPropertiesArgs(args, topic); r != nil {
+			return r
+		}
 	}
 	return nil
 }
@@ -998,66 +1148,30 @@ func (h *XMindHandler) SetTopicPropertiesBulk(ctx context.Context, req mcp.CallT
 		return terr, nil
 	}
 
-	raw, has := args["topic_ids"]
-	if !has {
-		return mcp.NewToolResultError("missing required argument: topic_ids"), nil
-	}
-	rawIDs, ok := raw.([]any)
-	if !ok {
-		return mcp.NewToolResultError("invalid argument topic_ids: expected an array"), nil
-	}
-	topicIDs := make([]string, 0, len(rawIDs))
-	seen := make(map[string]struct{}, len(rawIDs))
-	for i, v := range rawIDs {
-		s, ok := v.(string)
-		if !ok || s == "" {
-			return mcp.NewToolResultError(fmt.Sprintf("topic_ids[%d]: expected non-empty string", i)), nil
-		}
-		if _, dup := seen[s]; dup {
-			return mcp.NewToolResultError(fmt.Sprintf("duplicate id in topic_ids: %s", s)), nil
-		}
-		seen[s] = struct{}{}
-		topicIDs = append(topicIDs, s)
-	}
-	if len(topicIDs) == 0 {
-		return mcp.NewToolResultError("topic_ids must be non-empty"), nil
+	topicIDs, idErr := parseTopicIDsArgs(args)
+	if idErr != nil {
+		return idErr, nil
 	}
 
 	if !hasActionableTopicPropertyArgs(args) {
 		return mcp.NewToolResultError("missing property updates: provide at least one of notes, labels, markers, remove_markers, or link"), nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sh, sheetErr, err := loadSheetByID(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
-	if toolErr2 != nil {
-		return toolErr2, nil
-	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	if sheetErr != nil {
+		return sheetErr, nil
 	}
 
-	topics := make([]*xmind.Topic, 0, len(topicIDs))
-	missing := make([]string, 0)
-	for _, id := range topicIDs {
-		t := findTopicByID(&sh.RootTopic, id)
-		if t == nil {
-			missing = append(missing, id)
-		} else {
-			topics = append(topics, t)
-		}
-	}
-	if len(missing) > 0 {
-		slices.Sort(missing)
-		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", strings.Join(missing, ", "))), nil
+	topics, missErr := resolveTopicsForSheet(&sh.RootTopic, topicIDs)
+	if missErr != nil {
+		return missErr, nil
 	}
 
-	for _, topic := range topics {
-		if toolResult := applyTopicPropertiesArgs(args, topic); toolResult != nil {
-			return toolResult, nil
-		}
+	if toolResult := applyTopicPropertiesToTopics(args, topics); toolResult != nil {
+		return toolResult, nil
 	}
 
 	sh.RevisionID = uuid.New().String()

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -52,6 +52,302 @@ func parseMoveTopicResult(t *testing.T, res *mcp.CallToolResult) moveTopicRespon
 	return out
 }
 
+func parseDuplicateTopicResult(t *testing.T, res *mcp.CallToolResult) duplicateTopicResponse {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("expected success, got tool error: %s", textContent(t, res))
+	}
+	var out duplicateTopicResponse
+	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
+		t.Fatalf("parse duplicate topic JSON: %v", err)
+	}
+	return out
+}
+
+func readZipContentJSON(t *testing.T, path string) []byte {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = zr.Close() }()
+	for _, f := range zr.File {
+		if f.Name != "content.json" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return raw
+	}
+	t.Fatal("content.json not found in zip")
+	return nil
+}
+
+func assertNestedBulkL1L2L3(t *testing.T, rt *xmind.Topic, bulk addTopicsBulkResponse, rootID string) {
+	t.Helper()
+	if bulk.ParentID != rootID {
+		t.Fatalf("unexpected parentId: got %q want %q", bulk.ParentID, rootID)
+	}
+	if rt.Children == nil || len(rt.Children.Attached) != 1 {
+		t.Fatal("expected one top-level branch")
+	}
+	l1 := &rt.Children.Attached[0]
+	if bulk.RootTopicIDs[0] != l1.ID {
+		t.Fatalf("rootTopicIds[0] %q != L1 id %q", bulk.RootTopicIDs[0], l1.ID)
+	}
+	assertTopicTitleOneChild(t, l1, "L1", "L2")
+	l2 := &l1.Children.Attached[0]
+	assertTopicTitleOneChild(t, l2, "L2", "L3")
+	l3 := &l2.Children.Attached[0]
+	if l3.Title != "L3" {
+		t.Fatalf("L3: %+v", l3)
+	}
+}
+
+func assertTopicTitleOneChild(t *testing.T, topic *xmind.Topic, wantTitle, childTitle string) {
+	t.Helper()
+	if topic.Title != wantTitle {
+		t.Fatalf("want title %q, got %+v", wantTitle, topic)
+	}
+	if topic.Children == nil || len(topic.Children.Attached) != 1 {
+		t.Fatalf("%s: want one child, got %+v", wantTitle, topic.Children)
+	}
+	if topic.Children.Attached[0].Title != childTitle {
+		t.Fatalf("%s: want child %q, got %+v", wantTitle, childTitle, topic.Children.Attached[0])
+	}
+}
+
+func assertTopicInlineMetadata(t *testing.T, topic *xmind.Topic, wantTitle, wantNote, wantLink string) {
+	t.Helper()
+	if topic == nil {
+		t.Fatal("topic not found after add")
+	}
+	if topic.Title != wantTitle {
+		t.Fatalf("title: got %q", topic.Title)
+	}
+	assertTopicNotesPlainAndHTML(t, topic, wantNote)
+	assertTopicLabelsAB(t, topic)
+	assertTopicMarkersPriorityDone(t, topic)
+	if topic.Href != wantLink {
+		t.Fatalf("href: got %q want %q", topic.Href, wantLink)
+	}
+}
+
+func assertTopicNotesPlainAndHTML(t *testing.T, topic *xmind.Topic, wantNote string) {
+	t.Helper()
+	if topic.Notes == nil || topic.Notes.Plain == nil || topic.Notes.Plain.Content != wantNote {
+		t.Fatalf("notes plain: %+v", topic.Notes)
+	}
+	if topic.Notes.RealHTML == nil || topic.Notes.RealHTML.Content == "" {
+		t.Fatalf("notes realHTML missing: %+v", topic.Notes)
+	}
+}
+
+func assertTopicLabelsAB(t *testing.T, topic *xmind.Topic) {
+	t.Helper()
+	if len(topic.Labels) != 2 || topic.Labels[0] != "a" || topic.Labels[1] != "b" {
+		t.Fatalf("labels: %+v", topic.Labels)
+	}
+}
+
+func assertTopicMarkersPriorityDone(t *testing.T, topic *xmind.Topic) {
+	t.Helper()
+	if len(topic.Markers) != 2 || topic.Markers[0].MarkerID != "priority-1" || topic.Markers[1].MarkerID != "task-done" {
+		t.Fatalf("markers: %+v", topic.Markers)
+	}
+}
+
+func assertBulkMetaParentChild(t *testing.T, rt *xmind.Topic) {
+	t.Helper()
+	if rt.Children == nil || len(rt.Children.Attached) != 1 {
+		t.Fatal("expected one top-level branch")
+	}
+	parent := &rt.Children.Attached[0]
+	assertBulkMetaParent(t, parent)
+	if parent.Children == nil || len(parent.Children.Attached) != 1 {
+		t.Fatal("expected one child")
+	}
+	assertBulkMetaChild(t, &parent.Children.Attached[0])
+}
+
+func assertBulkMetaParent(t *testing.T, parent *xmind.Topic) {
+	t.Helper()
+	if parent.Title != "Parent" || parent.Notes == nil || parent.Notes.Plain == nil || parent.Notes.Plain.Content != "parent note" {
+		t.Fatalf("parent metadata: %+v", parent)
+	}
+}
+
+func assertBulkMetaChild(t *testing.T, child *xmind.Topic) {
+	t.Helper()
+	if child.Title != "Child" || len(child.Markers) != 1 || child.Markers[0].MarkerID != "task-ongoing" {
+		t.Fatalf("child metadata: %+v", child)
+	}
+}
+
+func assertMoveResponseBasic(t *testing.T, mv moveTopicResponse, topicID, parentID string, pos int, sib int) {
+	t.Helper()
+	if mv.TopicID != topicID || mv.ParentID != parentID || mv.Position != pos || mv.SiblingCount != sib {
+		t.Fatalf("unexpected move response: %+v", mv)
+	}
+}
+
+func assertRootOnlyChildIs(t *testing.T, root *xmind.Topic, childID string) {
+	t.Helper()
+	if root.Children == nil || len(root.Children.Attached) != 1 || root.Children.Attached[0].ID != childID {
+		t.Fatalf("root should have only %s as direct child; got %+v", childID, root.Children)
+	}
+}
+
+func assertGammaHasOnlyChildAlpha(t *testing.T, root *xmind.Topic, gammaID, alphaID string) {
+	t.Helper()
+	gamma := findTopicByID(root, gammaID)
+	if gamma == nil {
+		t.Fatal("Gamma not found")
+	}
+	if gamma.Children == nil || len(gamma.Children.Attached) != 1 {
+		t.Fatalf("Gamma should have exactly 1 child; got %+v", gamma.Children)
+	}
+	if gamma.Children.Attached[0].ID != alphaID {
+		t.Fatalf("expected Alpha under Gamma; got %+v", gamma.Children.Attached[0])
+	}
+	if findTopicByID(root, alphaID) == nil {
+		t.Fatal("Alpha was lost from the tree")
+	}
+}
+
+func assertSetTopicPropertiesRoot(t *testing.T, topic *xmind.Topic) {
+	t.Helper()
+	assertNoteBodyDiv(t, topic)
+	if len(topic.Labels) != 2 || topic.Labels[0] != "l1" || topic.Labels[1] != "l2" {
+		t.Fatalf("labels: %v", topic.Labels)
+	}
+	if len(topic.Markers) != 1 || topic.Markers[0].MarkerID != "priority-1" {
+		t.Fatalf("markers: %+v", topic.Markers)
+	}
+	if topic.Href != "https://example.com" {
+		t.Fatalf("href: %q", topic.Href)
+	}
+}
+
+func assertNoteBodyDiv(t *testing.T, topic *xmind.Topic) {
+	t.Helper()
+	if topic.Notes == nil || topic.Notes.Plain == nil || topic.Notes.Plain.Content != "Note body" ||
+		topic.Notes.RealHTML == nil || topic.Notes.RealHTML.Content != "<div>Note body</div>" {
+		t.Fatalf("notes: %+v", topic.Notes)
+	}
+}
+
+func setupSummaryRangeKitchenSink(t *testing.T, h *XMindHandler, path string, sid, rid string) {
+	t.Helper()
+	for _, title := range []string{"A", "B", "C"} {
+		callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": title})
+	}
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := &sheets[0].RootTopic
+	sumTopicID := uuid.New().String()
+	root.Summaries = []xmind.Summary{{ID: uuid.New().String(), Range: "(0,2)", TopicID: sumTopicID}}
+	if root.Children == nil {
+		t.Fatal("expected children")
+	}
+	root.Children.Summary = []xmind.Topic{{ID: sumTopicID, Title: "S"}}
+	if err := xmind.WriteMap(path, sheets); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func topicIDWithTitle(root *xmind.Topic, title string) string {
+	if root.Children == nil {
+		return ""
+	}
+	for i := range root.Children.Attached {
+		if root.Children.Attached[i].Title == title {
+			return root.Children.Attached[i].ID
+		}
+	}
+	return ""
+}
+
+func mustSetTopicProperties(t *testing.T, h *XMindHandler, args map[string]any) {
+	t.Helper()
+	res := callTool(t, h.SetTopicProperties, args)
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+}
+
+func assertRootMarkerCount(t *testing.T, path string, want int, desc string) {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := sheets[0].RootTopic.Markers
+	if len(m) != want {
+		t.Fatalf("%s: want %d markers, got %+v", desc, want, m)
+	}
+}
+
+func assertRootMarkersOnlyB(t *testing.T, path string) {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := sheets[0].RootTopic.Markers
+	if len(m) != 1 || m[0].MarkerID != "b" {
+		t.Fatalf("markers then remove: want [b], got %+v", m)
+	}
+}
+
+func assertDuplicateHappyPathTree(t *testing.T, root *xmind.Topic, mid, newID string) {
+	t.Helper()
+	if root.Children == nil || len(root.Children.Attached) != 2 {
+		t.Fatalf("want 2 attached children on root (original Mid + duplicate), got %+v", root.Children)
+	}
+	if root.Children.Attached[0].ID != mid {
+		t.Fatalf("first child should be original Mid %s", mid)
+	}
+	if root.Children.Attached[1].ID != newID {
+		t.Fatalf("second child should be duplicate root %s, got %s", newID, root.Children.Attached[1].ID)
+	}
+	if root.Children.Attached[1].Title != "Mid" {
+		t.Fatalf("duplicate title: %+v", root.Children.Attached[1])
+	}
+	dup := root.Children.Attached[1]
+	if dup.Children == nil || len(dup.Children.Attached) != 1 ||
+		dup.Children.Attached[0].Title != "Leaf" {
+		t.Fatalf("duplicate should include Leaf: %+v", dup.Children)
+	}
+}
+
+func assertPostAddTopicChildPersisted(t *testing.T, path, revBefore, newID string) {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sheets[0].RevisionID == revBefore {
+		t.Fatal("expected sheet RevisionID to change after AddTopic")
+	}
+	rt := sheets[0].RootTopic
+	if rt.Children == nil || len(rt.Children.Attached) != 1 {
+		t.Fatalf("expected one attached child, got %+v", rt.Children)
+	}
+	if rt.Children.Attached[0].ID != newID || rt.Children.Attached[0].Title != "Child" {
+		t.Fatalf("unexpected child: %+v", rt.Children.Attached[0])
+	}
+}
+
 func TestAddTopicAndRevisionID(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()
@@ -85,20 +381,7 @@ func TestAddTopicAndRevisionID(t *testing.T) {
 		t.Fatalf("unexpected add topic response: %+v", added)
 	}
 
-	sheets, err = xmind.ReadMap(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sheets[0].RevisionID == revBefore {
-		t.Fatal("expected sheet RevisionID to change after AddTopic")
-	}
-	rt := sheets[0].RootTopic
-	if rt.Children == nil || len(rt.Children.Attached) != 1 {
-		t.Fatalf("expected one attached child, got %+v", rt.Children)
-	}
-	if rt.Children.Attached[0].ID != newID || rt.Children.Attached[0].Title != "Child" {
-		t.Fatalf("unexpected child: %+v", rt.Children.Attached[0])
-	}
+	assertPostAddTopicChildPersisted(t, path, revBefore, newID)
 }
 
 func TestAddTopicTitleAmpersandWritesLiteralContentJSON(t *testing.T) {
@@ -124,27 +407,7 @@ func TestAddTopicTitleAmpersandWritesLiteralContentJSON(t *testing.T) {
 	if res.IsError {
 		t.Fatal(textContent(t, res))
 	}
-	zr, err := zip.OpenReader(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = zr.Close() }()
-	var raw []byte
-	for _, f := range zr.File {
-		if f.Name != "content.json" {
-			continue
-		}
-		rc, err := f.Open()
-		if err != nil {
-			t.Fatal(err)
-		}
-		raw, err = io.ReadAll(rc)
-		_ = rc.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		break
-	}
+	raw := readZipContentJSON(t, path)
 	if len(raw) == 0 {
 		t.Fatal("content.json not found or empty in zip")
 	}
@@ -201,33 +464,13 @@ func TestAddTopicsBulkNested(t *testing.T) {
 	if bulk.AddedCount != 3 || len(bulk.RootTopicIDs) != 1 || bulk.FirstPosition != 0 || bulk.SiblingCount != 1 {
 		t.Fatalf("unexpected bulk response: %+v", bulk)
 	}
-	if bulk.ParentID != rootID {
-		t.Fatalf("unexpected parentId: got %q want %q", bulk.ParentID, rootID)
-	}
 
 	sheets, err = xmind.ReadMap(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	rt := sheets[0].RootTopic
-	if rt.Children == nil || len(rt.Children.Attached) != 1 {
-		t.Fatal("expected one top-level branch")
-	}
-	l1 := &rt.Children.Attached[0]
-	if bulk.RootTopicIDs[0] != l1.ID {
-		t.Fatalf("rootTopicIds[0] %q != L1 id %q", bulk.RootTopicIDs[0], l1.ID)
-	}
-	if l1.Title != "L1" || l1.Children == nil || len(l1.Children.Attached) != 1 {
-		t.Fatalf("L1: %+v", l1)
-	}
-	l2 := &l1.Children.Attached[0]
-	if l2.Title != "L2" || l2.Children == nil || len(l2.Children.Attached) != 1 {
-		t.Fatalf("L2: %+v", l2)
-	}
-	l3 := &l2.Children.Attached[0]
-	if l3.Title != "L3" {
-		t.Fatalf("L3: %+v", l3)
-	}
+	rt := &sheets[0].RootTopic
+	assertNestedBulkL1L2L3(t, rt, bulk, rootID)
 }
 
 func TestAddTopicWithInlineMetadata(t *testing.T) {
@@ -267,27 +510,7 @@ func TestAddTopicWithInlineMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	topic := findTopicByID(&sheets[0].RootTopic, newID)
-	if topic == nil {
-		t.Fatal("topic not found after add")
-	}
-	if topic.Title != "WithMeta" {
-		t.Fatalf("title: got %q", topic.Title)
-	}
-	if topic.Notes == nil || topic.Notes.Plain == nil || topic.Notes.Plain.Content != wantNote {
-		t.Fatalf("notes plain: %+v", topic.Notes)
-	}
-	if topic.Notes.RealHTML == nil || topic.Notes.RealHTML.Content == "" {
-		t.Fatalf("notes realHTML missing: %+v", topic.Notes)
-	}
-	if len(topic.Labels) != 2 || topic.Labels[0] != "a" || topic.Labels[1] != "b" {
-		t.Fatalf("labels: %+v", topic.Labels)
-	}
-	if len(topic.Markers) != 2 || topic.Markers[0].MarkerID != "priority-1" || topic.Markers[1].MarkerID != "task-done" {
-		t.Fatalf("markers: %+v", topic.Markers)
-	}
-	if topic.Href != wantLink {
-		t.Fatalf("href: got %q want %q", topic.Href, wantLink)
-	}
+	assertTopicInlineMetadata(t, topic, "WithMeta", wantNote, wantLink)
 }
 
 func TestAddTopicsBulkWithPerTopicMetadata(t *testing.T) {
@@ -334,21 +557,7 @@ func TestAddTopicsBulkWithPerTopicMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rt := sheets[0].RootTopic
-	if rt.Children == nil || len(rt.Children.Attached) != 1 {
-		t.Fatal("expected one top-level branch")
-	}
-	parent := &rt.Children.Attached[0]
-	if parent.Title != "Parent" || parent.Notes == nil || parent.Notes.Plain == nil || parent.Notes.Plain.Content != "parent note" {
-		t.Fatalf("parent metadata: %+v", parent)
-	}
-	if parent.Children == nil || len(parent.Children.Attached) != 1 {
-		t.Fatal("expected one child")
-	}
-	child := &parent.Children.Attached[0]
-	if child.Title != "Child" || len(child.Markers) != 1 || child.Markers[0].MarkerID != "task-ongoing" {
-		t.Fatalf("child metadata: %+v", child)
-	}
+	assertBulkMetaParentChild(t, &sheets[0].RootTopic)
 }
 
 func TestAddTopicsBulkMalformedMarkersToolError(t *testing.T) {
@@ -669,14 +878,10 @@ func TestMoveTopic(t *testing.T) {
 		t.Fatal(textContent(t, res))
 	}
 	mv := parseMoveTopicResult(t, res)
-	if mv.TopicID != bID || mv.ParentID != aID || mv.Position != 0 || mv.SiblingCount != 1 {
-		t.Fatalf("unexpected move response: %+v", mv)
-	}
+	assertMoveResponseBasic(t, mv, bID, aID, 0, 1)
 	sheets, _ = xmind.ReadMap(path)
 	root := &sheets[0].RootTopic
-	if root.Children == nil || len(root.Children.Attached) != 1 || root.Children.Attached[0].ID != aID {
-		t.Fatalf("root should have only A after move; got %+v", root.Children)
-	}
+	assertRootOnlyChildIs(t, root, aID)
 	a := findTopicByID(root, aID)
 	if a == nil || a.Children == nil || len(a.Children.Attached) != 1 || a.Children.Attached[0].ID != bID {
 		t.Fatalf("B not under A: %+v", a)
@@ -718,37 +923,12 @@ func TestMoveTopicSiblingForward(t *testing.T) {
 		t.Fatalf("MoveTopic: %s", textContent(t, res))
 	}
 	mv := parseMoveTopicResult(t, res)
-	if mv.TopicID != alphaID || mv.ParentID != gammaID || mv.Position != 0 || mv.SiblingCount != 1 {
-		t.Fatalf("unexpected move response: %+v", mv)
-	}
+	assertMoveResponseBasic(t, mv, alphaID, gammaID, 0, 1)
 
 	sheets, _ = xmind.ReadMap(path)
 	root := &sheets[0].RootTopic
-
-	// Root should have only Gamma as a direct child.
-	if root.Children == nil || len(root.Children.Attached) != 1 {
-		t.Fatalf("root should have exactly 1 child after move; got %+v", root.Children)
-	}
-	if root.Children.Attached[0].ID != gammaID {
-		t.Fatalf("expected Gamma as root's only child; got %+v", root.Children.Attached[0])
-	}
-
-	// Gamma should have Alpha as a child.
-	gamma := findTopicByID(root, gammaID)
-	if gamma == nil {
-		t.Fatal("Gamma not found")
-	}
-	if gamma.Children == nil || len(gamma.Children.Attached) != 1 {
-		t.Fatalf("Gamma should have exactly 1 child; got %+v", gamma.Children)
-	}
-	if gamma.Children.Attached[0].ID != alphaID {
-		t.Fatalf("expected Alpha under Gamma; got %+v", gamma.Children.Attached[0])
-	}
-
-	// Alpha must still exist in the tree (was being silently dropped before fix).
-	if findTopicByID(root, alphaID) == nil {
-		t.Fatal("Alpha was lost from the tree (stale-pointer bug)")
-	}
+	assertRootOnlyChildIs(t, root, gammaID)
+	assertGammaHasOnlyChildAlpha(t, root, gammaID, alphaID)
 }
 
 // TestMoveTopicSiblingBackward moves a topic to a sibling that appears BEFORE it
@@ -782,33 +962,12 @@ func TestMoveTopicSiblingBackward(t *testing.T) {
 		t.Fatalf("MoveTopic: %s", textContent(t, res))
 	}
 	mv := parseMoveTopicResult(t, res)
-	if mv.TopicID != alphaID || mv.ParentID != gammaID || mv.Position != 0 || mv.SiblingCount != 1 {
-		t.Fatalf("unexpected move response: %+v", mv)
-	}
+	assertMoveResponseBasic(t, mv, alphaID, gammaID, 0, 1)
 
 	sheets, _ = xmind.ReadMap(path)
 	root := &sheets[0].RootTopic
-
-	if root.Children == nil || len(root.Children.Attached) != 1 {
-		t.Fatalf("root should have exactly 1 child after move; got %+v", root.Children)
-	}
-	if root.Children.Attached[0].ID != gammaID {
-		t.Fatalf("expected Gamma as root's only child; got %+v", root.Children.Attached[0])
-	}
-
-	gamma := findTopicByID(root, gammaID)
-	if gamma == nil {
-		t.Fatal("Gamma not found")
-	}
-	if gamma.Children == nil || len(gamma.Children.Attached) != 1 {
-		t.Fatalf("Gamma should have exactly 1 child; got %+v", gamma.Children)
-	}
-	if gamma.Children.Attached[0].ID != alphaID {
-		t.Fatalf("expected Alpha under Gamma; got %+v", gamma.Children.Attached[0])
-	}
-	if findTopicByID(root, alphaID) == nil {
-		t.Fatal("Alpha was lost from the tree")
-	}
+	assertRootOnlyChildIs(t, root, gammaID)
+	assertGammaHasOnlyChildAlpha(t, root, gammaID, alphaID)
 }
 
 func TestReorderChildrenMismatch(t *testing.T) {
@@ -886,20 +1045,7 @@ func TestSetTopicProperties(t *testing.T) {
 		t.Fatal(textContent(t, res))
 	}
 	sheets, _ = xmind.ReadMap(path)
-	topic := &sheets[0].RootTopic
-	if topic.Notes == nil || topic.Notes.Plain == nil || topic.Notes.Plain.Content != "Note body" ||
-		topic.Notes.RealHTML == nil || topic.Notes.RealHTML.Content != "<div>Note body</div>" {
-		t.Fatalf("notes: %+v", topic.Notes)
-	}
-	if len(topic.Labels) != 2 || topic.Labels[0] != "l1" || topic.Labels[1] != "l2" {
-		t.Fatalf("labels: %v", topic.Labels)
-	}
-	if len(topic.Markers) != 1 || topic.Markers[0].MarkerID != "priority-1" {
-		t.Fatalf("markers: %+v", topic.Markers)
-	}
-	if topic.Href != "https://example.com" {
-		t.Fatalf("href: %q", topic.Href)
-	}
+	assertSetTopicPropertiesRoot(t, &sheets[0].RootTopic)
 }
 
 func TestAddFloatingTopic(t *testing.T) {
@@ -1022,31 +1168,12 @@ func TestDeleteTopicCollapsesSummaryRange(t *testing.T) {
 	}
 	sid := sheets[0].ID
 	rid := sheets[0].RootTopic.ID
-	for _, title := range []string{"A", "B", "C"} {
-		callTool(t, h.AddTopic, map[string]any{"path": path, "sheet_id": sid, "parent_id": rid, "title": title})
-	}
+	setupSummaryRangeKitchenSink(t, h, path, sid, rid)
 	sheets, err = xmind.ReadMap(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	root := &sheets[0].RootTopic
-	sumTopicID := uuid.New().String()
-	root.Summaries = []xmind.Summary{{ID: uuid.New().String(), Range: "(0,2)", TopicID: sumTopicID}}
-	if root.Children == nil {
-		t.Fatal("expected children")
-	}
-	root.Children.Summary = []xmind.Topic{{ID: sumTopicID, Title: "S"}}
-	if err := xmind.WriteMap(path, sheets); err != nil {
-		t.Fatal(err)
-	}
-
-	var bID string
-	for i := range root.Children.Attached {
-		if root.Children.Attached[i].Title == "B" {
-			bID = root.Children.Attached[i].ID
-			break
-		}
-	}
+	bID := topicIDWithTitle(&sheets[0].RootTopic, "B")
 	if bID == "" {
 		t.Fatal("topic B not found")
 	}
@@ -1059,7 +1186,7 @@ func TestDeleteTopicCollapsesSummaryRange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	root = &sheets[0].RootTopic
+	root := &sheets[0].RootTopic
 	if len(root.Summaries) != 1 || root.Summaries[0].Range != "(0,1)" {
 		t.Fatalf("want summary range (0,1), got %+v", root.Summaries)
 	}
@@ -1101,6 +1228,17 @@ func TestSetTopicPropertiesPartial(t *testing.T) {
 	}
 }
 
+func assertRootNotesNilAfter(t *testing.T, path, label string) {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sheets[0].RootTopic.Notes != nil {
+		t.Fatalf("%s: want nil notes, got %+v", label, sheets[0].RootTopic.Notes)
+	}
+}
+
 func TestSetTopicPropertiesClearSemantics(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()
@@ -1110,71 +1248,43 @@ func TestSetTopicPropertiesClearSemantics(t *testing.T) {
 	sid := sheets[0].ID
 	tid := sheets[0].RootTopic.ID
 
-	res := callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"notes": "keep", "labels": []any{"x"}, "markers": []any{"priority-1"}, "link": "https://a.example",
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid, "notes": "",
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	sheets, _ = xmind.ReadMap(path)
-	if sheets[0].RootTopic.Notes != nil {
-		t.Fatalf("notes empty string: want nil, got %+v", sheets[0].RootTopic.Notes)
-	}
+	assertRootNotesNilAfter(t, path, "notes empty string")
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"notes": "n2", "labels": []any{"y"}, "markers": []any{"task-done"}, "link": "https://b.example",
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid, "notes": nil,
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	sheets, _ = xmind.ReadMap(path)
-	if sheets[0].RootTopic.Notes != nil {
-		t.Fatalf("notes nil: want nil, got %+v", sheets[0].RootTopic.Notes)
-	}
+	assertRootNotesNilAfter(t, path, "notes nil")
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid, "labels": []any{},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
 	sheets, _ = xmind.ReadMap(path)
 	if len(sheets[0].RootTopic.Labels) != 0 {
 		t.Fatalf("labels: want empty, got %v", sheets[0].RootTopic.Labels)
 	}
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid, "markers": []any{},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
 	sheets, _ = xmind.ReadMap(path)
 	if len(sheets[0].RootTopic.Markers) != 0 {
 		t.Fatalf("markers: want empty, got %+v", sheets[0].RootTopic.Markers)
 	}
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid, "link": "",
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
 	sheets, _ = xmind.ReadMap(path)
 	if sheets[0].RootTopic.Href != "" {
 		t.Fatalf("link: want empty href, got %q", sheets[0].RootTopic.Href)
@@ -1190,88 +1300,55 @@ func TestSetTopicPropertiesRemoveMarkers(t *testing.T) {
 	sid := sheets[0].ID
 	tid := sheets[0].RootTopic.ID
 
-	res := callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"markers": []any{"priority-1", "task-done"},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"remove_markers": []any{},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	sheets, _ = xmind.ReadMap(path)
-	m := sheets[0].RootTopic.Markers
-	if len(m) != 2 {
-		t.Fatalf("empty remove_markers: want two markers, got %+v", m)
-	}
+	assertRootMarkerCount(t, path, 2, "empty remove_markers")
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"remove_markers": []any{"unknown-id"},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	sheets, _ = xmind.ReadMap(path)
-	m = sheets[0].RootTopic.Markers
-	if len(m) != 2 {
-		t.Fatalf("unknown remove id: want two markers, got %+v", m)
-	}
+	assertRootMarkerCount(t, path, 2, "unknown remove id")
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"remove_markers": []any{"priority-1"},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
 	sheets, _ = xmind.ReadMap(path)
-	m = sheets[0].RootTopic.Markers
+	m := sheets[0].RootTopic.Markers
 	if len(m) != 1 || m[0].MarkerID != "task-done" {
 		t.Fatalf("partial remove: want [task-done], got %+v", m)
 	}
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"markers": []any{},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
 	sheets, _ = xmind.ReadMap(path)
 	if len(sheets[0].RootTopic.Markers) != 0 {
 		t.Fatalf("markers empty array: want no markers, got %+v", sheets[0].RootTopic.Markers)
 	}
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"remove_markers": []any{"still-unknown"},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
 	sheets, _ = xmind.ReadMap(path)
 	if len(sheets[0].RootTopic.Markers) != 0 {
 		t.Fatalf("remove_markers with no markers: want empty, got %+v", sheets[0].RootTopic.Markers)
 	}
 
-	res = callTool(t, h.SetTopicProperties, map[string]any{
+	mustSetTopicProperties(t, h, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": tid,
 		"markers": []any{"a", "b"}, "remove_markers": []any{"a"},
 	})
-	if res.IsError {
-		t.Fatal(textContent(t, res))
-	}
-	sheets, _ = xmind.ReadMap(path)
-	m = sheets[0].RootTopic.Markers
-	if len(m) != 1 || m[0].MarkerID != "b" {
-		t.Fatalf("markers then remove: want [b], got %+v", m)
-	}
+	assertRootMarkersOnlyB(t, path)
 }
 
 func nestBulkTopic(depth int) any {
@@ -2125,13 +2202,7 @@ func TestDuplicateTopicHappyPath(t *testing.T) {
 	res := callTool(t, h.DuplicateTopic, map[string]any{
 		"path": path, "sheet_id": sid, "topic_id": mid, "target_parent_id": rid,
 	})
-	if res.IsError {
-		t.Fatalf("DuplicateTopic: %s", textContent(t, res))
-	}
-	var dup duplicateTopicResponse
-	if err := json.Unmarshal([]byte(textContent(t, res)), &dup); err != nil {
-		t.Fatalf("parse duplicate topic JSON: %v", err)
-	}
+	dup := parseDuplicateTopicResult(t, res)
 	if dup.SourceID != mid || dup.ParentID != rid || dup.CopiedCount != 2 {
 		t.Fatalf("unexpected duplicate response: %+v", dup)
 	}
@@ -2147,22 +2218,7 @@ func TestDuplicateTopicHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	root := &sheets[0].RootTopic
-	if root.Children == nil || len(root.Children.Attached) != 2 {
-		t.Fatalf("want 2 attached children on root (original Mid + duplicate), got %+v", root.Children)
-	}
-	if root.Children.Attached[0].ID != mid {
-		t.Fatalf("first child should be original Mid %s", mid)
-	}
-	if root.Children.Attached[1].ID != newID {
-		t.Fatalf("second child should be duplicate root %s, got %s", newID, root.Children.Attached[1].ID)
-	}
-	if root.Children.Attached[1].Title != "Mid" {
-		t.Fatalf("duplicate title: %+v", root.Children.Attached[1])
-	}
-	if root.Children.Attached[1].Children == nil || len(root.Children.Attached[1].Children.Attached) != 1 ||
-		root.Children.Attached[1].Children.Attached[0].Title != "Leaf" {
-		t.Fatalf("duplicate should include Leaf: %+v", root.Children.Attached[1].Children)
-	}
+	assertDuplicateHappyPathTree(t, root, mid, newID)
 }
 
 func TestDuplicateTopicPositionInsertAtZeroAndAppend(t *testing.T) {

--- a/internal/server/handler/sheets.go
+++ b/internal/server/handler/sheets.go
@@ -139,6 +139,34 @@ type listRelationshipsItem struct {
 	Title     string `json:"title,omitempty"`
 }
 
+func listRelationshipsItems(sh *xmind.Sheet) []listRelationshipsItem {
+	rels := make([]listRelationshipsItem, 0, len(sh.Relationships))
+	for i := range sh.Relationships {
+		rel := &sh.Relationships[i]
+		item := listRelationshipItemFrom(sh, rel)
+		rels = append(rels, item)
+	}
+	return rels
+}
+
+func listRelationshipItemFrom(sh *xmind.Sheet, rel *xmind.Relationship) listRelationshipsItem {
+	item := listRelationshipsItem{
+		ID:     rel.ID,
+		End1ID: rel.End1ID,
+		End2ID: rel.End2ID,
+	}
+	if t1 := findTopicByID(&sh.RootTopic, rel.End1ID); t1 != nil {
+		item.End1Title = t1.Title
+	}
+	if t2 := findTopicByID(&sh.RootTopic, rel.End2ID); t2 != nil {
+		item.End2Title = t2.Title
+	}
+	if rel.Title != "" {
+		item.Title = rel.Title
+	}
+	return item
+}
+
 // ListRelationships returns all relationships on a sheet with endpoint topic titles.
 func (h *XMindHandler) ListRelationships(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
@@ -165,25 +193,7 @@ func (h *XMindHandler) ListRelationships(ctx context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
 
-	rels := make([]listRelationshipsItem, 0, len(sh.Relationships))
-	for i := range sh.Relationships {
-		rel := &sh.Relationships[i]
-		item := listRelationshipsItem{
-			ID:     rel.ID,
-			End1ID: rel.End1ID,
-			End2ID: rel.End2ID,
-		}
-		if t1 := findTopicByID(&sh.RootTopic, rel.End1ID); t1 != nil {
-			item.End1Title = t1.Title
-		}
-		if t2 := findTopicByID(&sh.RootTopic, rel.End2ID); t2 != nil {
-			item.End2Title = t2.Title
-		}
-		if rel.Title != "" {
-			item.Title = rel.Title
-		}
-		rels = append(rels, item)
-	}
+	rels := listRelationshipsItems(sh)
 
 	resp := listRelationshipsResponse{
 		SheetID:           sh.ID,
@@ -272,22 +282,13 @@ func (h *XMindHandler) AddSheet(ctx context.Context, req mcp.CallToolRequest) (*
 		return toolErr, nil
 	}
 
-	rawTitle, ok := args["title"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: title"), nil
+	sheetTitle, terr := requireString(args, "title")
+	if terr != nil {
+		return terr, nil
 	}
-	sheetTitle, ok := rawTitle.(string)
-	if !ok || sheetTitle == "" {
-		return mcp.NewToolResultError("invalid argument title: expected a non-empty string"), nil
-	}
-
-	rawRoot, ok := args["root_title"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: root_title"), nil
-	}
-	rootTitle, ok := rawRoot.(string)
-	if !ok || rootTitle == "" {
-		return mcp.NewToolResultError("invalid argument root_title: expected a non-empty string"), nil
+	rootTitle, terr := requireString(args, "root_title")
+	if terr != nil {
+		return terr, nil
 	}
 
 	sheets, toolErr2, err := statAndReadMap(absPath)

--- a/internal/server/handler/sheets_test.go
+++ b/internal/server/handler/sheets_test.go
@@ -55,6 +55,41 @@ func TestListSheetsKitchenSink(t *testing.T) {
 	}
 }
 
+func assertReadMapOneSheetTitles(t *testing.T, path, wantSheetTitle, wantRootTitle string) {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatalf("ReadMap: %v", err)
+	}
+	if len(sheets) != 1 {
+		t.Fatalf("sheet count: got %d want 1", len(sheets))
+	}
+	if got, want := sheets[0].Title, wantSheetTitle; got != want {
+		t.Fatalf("sheet title: got %q want %q", got, want)
+	}
+	if got, want := sheets[0].RootTopic.Title, wantRootTitle; got != want {
+		t.Fatalf("root title: got %q want %q", got, want)
+	}
+}
+
+func assertOpenMapListsOneSheet(t *testing.T, h *XMindHandler, path, wantSheetTitle, wantRootTitle string) {
+	t.Helper()
+	openRes := callTool(t, h.OpenMap, map[string]any{"path": path})
+	if openRes.IsError {
+		t.Fatalf("OpenMap after CreateMap: %s", textContent(t, openRes))
+	}
+	var om openMapResponse
+	if err := json.Unmarshal([]byte(textContent(t, openRes)), &om); err != nil {
+		t.Fatalf("OpenMap unmarshal: %v", err)
+	}
+	if om.SheetCount != 1 {
+		t.Fatalf("OpenMap sheetCount: got %d want 1", om.SheetCount)
+	}
+	if len(om.Sheets) != 1 || om.Sheets[0].Title != wantSheetTitle || om.Sheets[0].RootTopicTitle != wantRootTitle {
+		t.Fatalf("OpenMap sheets: %+v", om.Sheets)
+	}
+}
+
 func TestCreateMapOpenRead(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()
@@ -67,34 +102,8 @@ func TestCreateMapOpenRead(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("CreateMap: %s", textContent(t, res))
 	}
-	sheets, err := xmind.ReadMap(path)
-	if err != nil {
-		t.Fatalf("ReadMap: %v", err)
-	}
-	if len(sheets) != 1 {
-		t.Fatalf("sheet count: got %d want 1", len(sheets))
-	}
-	if got, want := sheets[0].Title, "My Sheet"; got != want {
-		t.Fatalf("sheet title: got %q want %q", got, want)
-	}
-	if got, want := sheets[0].RootTopic.Title, "Root A"; got != want {
-		t.Fatalf("root title: got %q want %q", got, want)
-	}
-
-	openRes := callTool(t, h.OpenMap, map[string]any{"path": path})
-	if openRes.IsError {
-		t.Fatalf("OpenMap after CreateMap: %s", textContent(t, openRes))
-	}
-	var om openMapResponse
-	if err := json.Unmarshal([]byte(textContent(t, openRes)), &om); err != nil {
-		t.Fatalf("OpenMap unmarshal: %v", err)
-	}
-	if om.SheetCount != 1 {
-		t.Fatalf("OpenMap sheetCount: got %d want 1", om.SheetCount)
-	}
-	if len(om.Sheets) != 1 || om.Sheets[0].Title != "My Sheet" || om.Sheets[0].RootTopicTitle != "Root A" {
-		t.Fatalf("OpenMap sheets: %+v", om.Sheets)
-	}
+	assertReadMapOneSheetTitles(t, path, "My Sheet", "Root A")
+	assertOpenMapListsOneSheet(t, h, path, "My Sheet", "Root A")
 }
 
 func TestCreateMapFileExists(t *testing.T) {
@@ -254,11 +263,10 @@ func TestDeleteLastSheetError(t *testing.T) {
 	}
 }
 
-func TestListRelationshipsKitchenSink(t *testing.T) {
-	h := NewXMindHandler()
+func mustListRelationshipsJSON(t *testing.T, h *XMindHandler, path, sheetID string) listRelationshipsResponse {
+	t.Helper()
 	res := callTool(t, h.ListRelationships, map[string]any{
-		"path":     kitchenSinkPath(t),
-		"sheet_id": kitchenSinkRelationshipsSheetID,
+		"path": path, "sheet_id": sheetID,
 	})
 	if res.IsError {
 		t.Fatalf("unexpected tool error: %s", textContent(t, res))
@@ -267,40 +275,49 @@ func TestListRelationshipsKitchenSink(t *testing.T) {
 	if err := json.Unmarshal([]byte(textContent(t, res)), &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.SheetID != kitchenSinkRelationshipsSheetID {
-		t.Fatalf("sheetId: got %q want %q", out.SheetID, kitchenSinkRelationshipsSheetID)
+	return out
+}
+
+func assertKitchenSinkRelationshipListHeader(t *testing.T, out *listRelationshipsResponse, wantSheetID string, wantRelCount int) {
+	t.Helper()
+	if out.SheetID != wantSheetID {
+		t.Fatalf("sheetId: got %q want %q", out.SheetID, wantSheetID)
 	}
-	const wantRelCount = 2 // kitchen-sink Sheet 12 (kitchenSinkRelationshipsSheetID)
 	if out.RelationshipCount != wantRelCount || len(out.Relationships) != wantRelCount {
 		t.Fatalf("relationshipCount/relationships: got count=%d len=%d want %d", out.RelationshipCount, len(out.Relationships), wantRelCount)
 	}
 	if len(out.Relationships) != out.RelationshipCount {
 		t.Fatalf("relationships len %d vs relationshipCount %d", len(out.Relationships), out.RelationshipCount)
 	}
-	foundNonEmpty := false
-	for _, r := range out.Relationships {
+}
+
+func assertSomeRelationshipHasEndTitles(t *testing.T, rels []listRelationshipsItem) {
+	t.Helper()
+	for _, r := range rels {
 		if r.End1Title != "" && r.End2Title != "" {
-			foundNonEmpty = true
-			break
+			return
 		}
 	}
-	if !foundNonEmpty {
-		t.Fatal("expected at least one relationship with non-empty end1Title and end2Title")
-	}
-	sheets, err := xmind.ReadMap(kitchenSinkPath(t))
+	t.Fatal("expected at least one relationship with non-empty end1Title and end2Title")
+}
+
+func findKitchenSinkSheetByID(t *testing.T, path, sheetID string) *xmind.Sheet {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var sh *xmind.Sheet
 	for i := range sheets {
-		if sheets[i].ID == kitchenSinkRelationshipsSheetID {
-			sh = &sheets[i]
-			break
+		if sheets[i].ID == sheetID {
+			return &sheets[i]
 		}
 	}
-	if sh == nil {
-		t.Fatal("sheet not found in kitchen sink")
-	}
+	t.Fatal("sheet not found in kitchen sink")
+	return nil
+}
+
+func assertFirstRelationshipMatchesSheet(t *testing.T, sh *xmind.Sheet, out *listRelationshipsResponse) {
+	t.Helper()
 	if len(sh.Relationships) != len(out.Relationships) {
 		t.Fatalf("ReadMap rel count %d vs list %d", len(sh.Relationships), len(out.Relationships))
 	}
@@ -318,6 +335,17 @@ func TestListRelationshipsKitchenSink(t *testing.T) {
 	if got.End1ID != sh.Relationships[0].End1ID || got.End2ID != sh.Relationships[0].End2ID {
 		t.Fatalf("endpoint ids: got %+v want End1=%q End2=%q", got, sh.Relationships[0].End1ID, sh.Relationships[0].End2ID)
 	}
+}
+
+func TestListRelationshipsKitchenSink(t *testing.T) {
+	h := NewXMindHandler()
+	path := kitchenSinkPath(t)
+	out := mustListRelationshipsJSON(t, h, path, kitchenSinkRelationshipsSheetID)
+	const wantRelCount = 2
+	assertKitchenSinkRelationshipListHeader(t, &out, kitchenSinkRelationshipsSheetID, wantRelCount)
+	assertSomeRelationshipHasEndTitles(t, out.Relationships)
+	sh := findKitchenSinkSheetByID(t, path, kitchenSinkRelationshipsSheetID)
+	assertFirstRelationshipMatchesSheet(t, sh, &out)
 }
 
 func TestListRelationshipsEmptySheet(t *testing.T) {

--- a/internal/server/handler/utils.go
+++ b/internal/server/handler/utils.go
@@ -452,124 +452,163 @@ func outlineNodeToTopics(n *outlineNode) xmind.Topic {
 	return t
 }
 
+type findReplaceChange struct {
+	SheetID  string `json:"sheetId,omitempty"`
+	ID       string `json:"id"`
+	OldTitle string `json:"oldTitle"`
+	NewTitle string `json:"newTitle"`
+}
+
+func exactMatchFromArgs(args map[string]any) (exact bool, toolErr *mcp.CallToolResult) {
+	if raw, has := args["exact_match"]; has && raw != nil {
+		v, ok := raw.(bool)
+		if !ok {
+			return false, mcp.NewToolResultError("invalid argument exact_match: expected a boolean")
+		}
+		return v, nil
+	}
+	return false, nil
+}
+
+func sheetsToUpdateForFindReplace(args map[string]any, sheets []xmind.Sheet) ([]*xmind.Sheet, *mcp.CallToolResult) {
+	if raw, has := args["sheet_id"]; has && raw != nil {
+		sheetID, ok := raw.(string)
+		if !ok || sheetID == "" {
+			return nil, mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string")
+		}
+		sh := findSheetByID(sheets, sheetID)
+		if sh == nil {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID))
+		}
+		return []*xmind.Sheet{sh}, nil
+	}
+	out := make([]*xmind.Sheet, 0, len(sheets))
+	for i := range sheets {
+		out = append(out, &sheets[i])
+	}
+	return out, nil
+}
+
+func findReplaceRegexp(find string) *regexp.Regexp {
+	return regexp.MustCompile("(?i)" + regexp.QuoteMeta(find))
+}
+
+func applyFindReplaceToTitle(oldTitle, find, replace string, exact bool, re *regexp.Regexp) (newTitle string, changed bool) {
+	if exact {
+		if !strings.EqualFold(oldTitle, find) {
+			return oldTitle, false
+		}
+		if replace == oldTitle {
+			return oldTitle, false
+		}
+		return replace, true
+	}
+	newTitle = re.ReplaceAllStringFunc(oldTitle, func(string) string { return replace })
+	if newTitle == oldTitle {
+		return oldTitle, false
+	}
+	return newTitle, true
+}
+
+func applyFindReplaceOnSheet(sh *xmind.Sheet, find, replace string, exact bool, re *regexp.Regexp, includeSheetID bool) []findReplaceChange {
+	var out []findReplaceChange
+	walkTopics(&sh.RootTopic, 0, nil, func(t *xmind.Topic, _ int, _ *xmind.Topic) bool {
+		old := t.Title
+		newTitle, changed := applyFindReplaceToTitle(old, find, replace, exact, re)
+		if !changed {
+			return true
+		}
+		c := findReplaceChange{ID: t.ID, OldTitle: old, NewTitle: newTitle}
+		if includeSheetID {
+			c.SheetID = sh.ID
+		}
+		out = append(out, c)
+		t.Title = newTitle
+		t.TitleUnedited = false
+		return true
+	})
+	if len(out) > 0 {
+		sh.RevisionID = uuid.New().String()
+	}
+	return out
+}
+
+func parseFindAndReplaceInputs(args map[string]any) (absPath, findStr, replaceStr string, exact bool, toolErr *mcp.CallToolResult) {
+	absPath, toolErr = absPathFromArgs(args)
+	if toolErr != nil {
+		return "", "", "", false, toolErr
+	}
+	findStr, toolErr = requireString(args, "find")
+	if toolErr != nil {
+		return "", "", "", false, toolErr
+	}
+	replaceStr, toolErr = stringArgAllowEmpty(args, "replace")
+	if toolErr != nil {
+		return "", "", "", false, toolErr
+	}
+	exact, toolErr = exactMatchFromArgs(args)
+	return absPath, findStr, replaceStr, exact, toolErr
+}
+
+func findAndReplaceLoadSheets(absPath string, args map[string]any) (sheets []xmind.Sheet, sheetsToUpdate []*xmind.Sheet, toolErr *mcp.CallToolResult, err error) {
+	sheets, toolErr, err = statAndReadMap(absPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if toolErr != nil {
+		return nil, nil, toolErr, nil
+	}
+	sheetsToUpdate, toolErr = sheetsToUpdateForFindReplace(args, sheets)
+	return sheets, sheetsToUpdate, toolErr, nil
+}
+
+func findReplaceRunOnSheets(sheetsToUpdate []*xmind.Sheet, findStr, replaceStr string, exact bool) []findReplaceChange {
+	var re *regexp.Regexp
+	if !exact {
+		re = findReplaceRegexp(findStr)
+	}
+	includeSheetID := len(sheetsToUpdate) > 1
+	var changes []findReplaceChange
+	for _, sh := range sheetsToUpdate {
+		changes = append(changes, applyFindReplaceOnSheet(sh, findStr, replaceStr, exact, re, includeSheetID)...)
+	}
+	return changes
+}
+
+func finishFindReplace(absPath string, sheets []xmind.Sheet, changes []findReplaceChange) (*mcp.CallToolResult, error) {
+	resp := struct {
+		ChangedCount int                 `json:"changedCount"`
+		Changes      []findReplaceChange `json:"changes"`
+	}{ChangedCount: len(changes), Changes: changes}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal find_and_replace response: %w", err)
+	}
+	if len(changes) > 0 {
+		if err := xmind.WriteMap(absPath, sheets); err != nil {
+			return nil, fmt.Errorf("write map: %w", err)
+		}
+	}
+	return textResult(string(out)), nil
+}
+
 // FindAndReplace updates topic titles. If sheet_id is omitted, all sheets are updated.
 func (h *XMindHandler) FindAndReplace(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
 	args := req.GetArguments()
-	absPath, toolErr := absPathFromArgs(args)
+	absPath, findStr, replaceStr, exact, toolErr := parseFindAndReplaceInputs(args)
 	if toolErr != nil {
 		return toolErr, nil
 	}
-	findStr, terr := requireString(args, "find")
-	if terr != nil {
-		return terr, nil
-	}
-	replaceStr, rerr := stringArgAllowEmpty(args, "replace")
-	if rerr != nil {
-		return rerr, nil
-	}
-	var exact bool
-	if raw, has := args["exact_match"]; has && raw != nil {
-		v, ok := raw.(bool)
-		if !ok {
-			return mcp.NewToolResultError("invalid argument exact_match: expected a boolean"), nil
-		}
-		exact = v
-	}
-
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, sheetsToUpdate, toolErr2, err := findAndReplaceLoadSheets(absPath, args)
 	if err != nil {
 		return nil, err
 	}
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
-
-	// Determine which sheets to update.
-	var sheetsToUpdate []*xmind.Sheet
-	if raw, has := args["sheet_id"]; has && raw != nil {
-		sheetID, ok := raw.(string)
-		if !ok || sheetID == "" {
-			return mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string"), nil
-		}
-		sh := findSheetByID(sheets, sheetID)
-		if sh == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-		}
-		sheetsToUpdate = []*xmind.Sheet{sh}
-	} else {
-		for i := range sheets {
-			sheetsToUpdate = append(sheetsToUpdate, &sheets[i])
-		}
-	}
-
-	type change struct {
-		SheetID  string `json:"sheetId,omitempty"`
-		ID       string `json:"id"`
-		OldTitle string `json:"oldTitle"`
-		NewTitle string `json:"newTitle"`
-	}
-	var changes []change
-
-	var re *regexp.Regexp
-	if !exact {
-		re = regexp.MustCompile("(?i)" + regexp.QuoteMeta(findStr))
-	}
-
-	multiSheet := len(sheetsToUpdate) > 1
-	for _, sh := range sheetsToUpdate {
-		prevLen := len(changes)
-		walkTopics(&sh.RootTopic, 0, nil, func(t *xmind.Topic, _ int, _ *xmind.Topic) bool {
-			old := t.Title
-			var newTitle string
-			if exact {
-				if strings.EqualFold(old, findStr) {
-					newTitle = replaceStr
-					if newTitle == old {
-						return true
-					}
-				} else {
-					return true
-				}
-			} else {
-				newTitle = re.ReplaceAllStringFunc(old, func(string) string { return replaceStr })
-				if newTitle == old {
-					return true
-				}
-			}
-			c := change{ID: t.ID, OldTitle: old, NewTitle: newTitle}
-			if multiSheet {
-				c.SheetID = sh.ID
-			}
-			changes = append(changes, c)
-			t.Title = newTitle
-			t.TitleUnedited = false
-			return true
-		})
-		if len(changes) > prevLen {
-			sh.RevisionID = uuid.New().String()
-		}
-	}
-
-	resp := struct {
-		ChangedCount int      `json:"changedCount"`
-		Changes      []change `json:"changes"`
-	}{
-		ChangedCount: len(changes),
-		Changes:      changes,
-	}
-	out, err := json.Marshal(resp)
-	if err != nil {
-		return nil, fmt.Errorf("marshal find_and_replace response: %w", err)
-	}
-
-	if len(changes) > 0 {
-		if err := xmind.WriteMap(absPath, sheets); err != nil {
-			return nil, fmt.Errorf("write map: %w", err)
-		}
-	}
-
-	return textResult(string(out)), nil
+	changes := findReplaceRunOnSheets(sheetsToUpdate, findStr, replaceStr, exact)
+	return finishFindReplace(absPath, sheets, changes)
 }
 
 func stringArgAllowEmpty(args map[string]any, key string) (string, *mcp.CallToolResult) {

--- a/internal/server/handler/utils.go
+++ b/internal/server/handler/utils.go
@@ -35,13 +35,9 @@ func (h *XMindHandler) FlattenToOutline(ctx context.Context, req mcp.CallToolReq
 	if terr != nil {
 		return terr, nil
 	}
-
-	format := "markdown"
-	if v, ok := args["format"].(string); ok && v != "" {
-		format = v
-	}
-	if format != "text" && format != "markdown" {
-		return mcp.NewToolResultError(`invalid argument format: expected "text" or "markdown"`), nil
+	format, includeNotes, optErr := outlineExportOptionsFromArgs(args)
+	if optErr != nil {
+		return optErr, nil
 	}
 
 	sheets, toolErr2, err := statAndReadMap(absPath)
@@ -56,24 +52,81 @@ func (h *XMindHandler) FlattenToOutline(ctx context.Context, req mcp.CallToolReq
 		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
 
-	var start *xmind.Topic
-	if v, ok := args["topic_id"].(string); ok && v != "" {
-		start = findTopicByID(&sh.RootTopic, v)
-		if start == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", v)), nil
-		}
-	} else {
-		start = &sh.RootTopic
-	}
-
-	includeNotes, berr := parseBoolOptional(args, "include_notes")
-	if berr != nil {
-		return berr, nil
+	start, stErr := outlineStartTopic(sh, args)
+	if stErr != nil {
+		return stErr, nil
 	}
 
 	var b strings.Builder
 	flattenTopicWrite(&b, start, 0, format, includeNotes)
 	return textResult(strings.TrimRight(b.String(), "\n")), nil
+}
+
+func outlineExportOptionsFromArgs(args map[string]any) (format string, includeNotes bool, toolErr *mcp.CallToolResult) {
+	format = "markdown"
+	if v, ok := args["format"].(string); ok && v != "" {
+		format = v
+	}
+	if format != "text" && format != "markdown" {
+		return "", false, mcp.NewToolResultError(`invalid argument format: expected "text" or "markdown"`)
+	}
+	var err *mcp.CallToolResult
+	includeNotes, err = parseBoolOptional(args, "include_notes")
+	if err != nil {
+		return "", false, err
+	}
+	return format, includeNotes, nil
+}
+
+func outlineStartTopic(sh *xmind.Sheet, args map[string]any) (*xmind.Topic, *mcp.CallToolResult) {
+	if v, ok := args["topic_id"].(string); ok && v != "" {
+		start := findTopicByID(&sh.RootTopic, v)
+		if start == nil {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", v))
+		}
+		return start, nil
+	}
+	return &sh.RootTopic, nil
+}
+
+func flattenTopicWriteText(b *strings.Builder, title, plain string, depth int, hasNotes bool) {
+	b.WriteString(strings.Repeat(" ", depth*2))
+	b.WriteString(title)
+	b.WriteByte('\n')
+	if !hasNotes {
+		return
+	}
+	noteIndent := strings.Repeat(" ", depth*2+4)
+	for _, line := range strings.Split(plain, "\n") {
+		b.WriteString(noteIndent)
+		b.WriteString("[note] ")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+}
+
+func flattenTopicWriteMarkdown(b *strings.Builder, title, plain string, depth int, hasNotes bool) {
+	// Use heading lines at every depth so import heading-mode parses the full tree (list lines would be ignored).
+	level := depth + 1
+	if level > 6 {
+		level = 6
+	}
+	b.WriteString(strings.Repeat("#", level))
+	b.WriteString(" ")
+	b.WriteString(title)
+	b.WriteByte('\n')
+	if hasNotes {
+		for _, line := range strings.Split(plain, "\n") {
+			b.WriteString("> ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+		return
+	}
+	if depth == 0 {
+		b.WriteByte('\n')
+	}
 }
 
 func flattenTopicWrite(b *strings.Builder, t *xmind.Topic, depth int, format string, includeNotes bool) {
@@ -87,38 +140,9 @@ func flattenTopicWrite(b *strings.Builder, t *xmind.Topic, depth int, format str
 
 	switch format {
 	case "text":
-		b.WriteString(strings.Repeat(" ", depth*2))
-		b.WriteString(title)
-		b.WriteByte('\n')
-		if hasNotes {
-			noteIndent := strings.Repeat(" ", depth*2+4)
-			for _, line := range strings.Split(plain, "\n") {
-				b.WriteString(noteIndent)
-				b.WriteString("[note] ")
-				b.WriteString(line)
-				b.WriteByte('\n')
-			}
-		}
+		flattenTopicWriteText(b, title, plain, depth, hasNotes)
 	case "markdown":
-		// Use heading lines at every depth so import heading-mode parses the full tree (list lines would be ignored).
-		level := depth + 1
-		if level > 6 {
-			level = 6
-		}
-		b.WriteString(strings.Repeat("#", level))
-		b.WriteString(" ")
-		b.WriteString(title)
-		b.WriteByte('\n')
-		if hasNotes {
-			for _, line := range strings.Split(plain, "\n") {
-				b.WriteString("> ")
-				b.WriteString(line)
-				b.WriteByte('\n')
-			}
-			b.WriteByte('\n')
-		} else if depth == 0 {
-			b.WriteByte('\n')
-		}
+		flattenTopicWriteMarkdown(b, title, plain, depth, hasNotes)
 	}
 	if t == nil || t.Children == nil {
 		return
@@ -140,16 +164,9 @@ func (h *XMindHandler) ImportFromOutline(ctx context.Context, req mcp.CallToolRe
 	if terr != nil {
 		return terr, nil
 	}
-
-	var sheetIDArg, parentIDArg string
-	if v, ok := args["sheet_id"].(string); ok {
-		sheetIDArg = v
-	}
-	if v, ok := args["parent_id"].(string); ok && v != "" {
-		parentIDArg = v
-	}
-	if parentIDArg != "" && sheetIDArg == "" {
-		return mcp.NewToolResultError("invalid arguments: parent_id requires sheet_id (omit parent_id when creating a new sheet)"), nil
+	sheetIDArg, parentIDArg, aerr := parseImportOutlineSheetArgs(args)
+	if aerr != nil {
+		return aerr, nil
 	}
 
 	pairs := parseOutlineToPairs(outline)
@@ -168,45 +185,63 @@ func (h *XMindHandler) ImportFromOutline(ctx context.Context, req mcp.CallToolRe
 	}
 
 	if sheetIDArg == "" {
-		// New sheet: single tree; first line is sheet+root title; extra depth-0 lines are children of root.
-		root := buildOutlineTreeSingleRoot(pairs)
-		if root == nil {
-			return mcp.NewToolResultError("could not build outline tree"), nil
-		}
-		bumpAllSheetsRevisionID(sheets)
-		sh := newSheet(root.title, root.title)
-		ch := ensureChildren(&sh.RootTopic)
-		for _, c := range root.children {
-			ch.Attached = append(ch.Attached, outlineNodeToTopics(c))
-		}
-		sheets = append(sheets, sh)
-		if err := xmind.WriteMap(absPath, sheets); err != nil {
-			return nil, fmt.Errorf("write map: %w", err)
-		}
-		n := countTopics(&sh.RootTopic)
-		return textResult(fmt.Sprintf("imported %d topics into new sheet id %s", n, sh.ID)), nil
+		return importOutlineNewSheet(absPath, sheets, pairs)
 	}
+	return importOutlineAppend(absPath, sheets, sheetIDArg, parentIDArg, pairs)
+}
 
-	sh := findSheetByID(sheets, sheetIDArg)
+func parseImportOutlineSheetArgs(args map[string]any) (sheetID, parentID string, toolErr *mcp.CallToolResult) {
+	if v, ok := args["sheet_id"].(string); ok {
+		sheetID = v
+	}
+	if v, ok := args["parent_id"].(string); ok && v != "" {
+		parentID = v
+	}
+	if parentID != "" && sheetID == "" {
+		return "", "", mcp.NewToolResultError("invalid arguments: parent_id requires sheet_id (omit parent_id when creating a new sheet)")
+	}
+	return sheetID, parentID, nil
+}
+
+// importOutlineNewSheet: single tree; first line is sheet+root title; extra depth-0 lines are children of root.
+func importOutlineNewSheet(absPath string, sheets []xmind.Sheet, pairs []outlinePair) (*mcp.CallToolResult, error) {
+	root := buildOutlineTreeSingleRoot(pairs)
+	if root == nil {
+		return mcp.NewToolResultError("could not build outline tree"), nil
+	}
+	bumpAllSheetsRevisionID(sheets)
+	sh := newSheet(root.title, root.title)
+	ch := ensureChildren(&sh.RootTopic)
+	for _, c := range root.children {
+		ch.Attached = append(ch.Attached, outlineNodeToTopics(c))
+	}
+	sheets = append(sheets, sh)
+	if err := xmind.WriteMap(absPath, sheets); err != nil {
+		return nil, fmt.Errorf("write map: %w", err)
+	}
+	n := countTopics(&sh.RootTopic)
+	return textResult(fmt.Sprintf("imported %d topics into new sheet id %s", n, sh.ID)), nil
+}
+
+func importOutlineAppend(absPath string, sheets []xmind.Sheet, sheetID, parentID string, pairs []outlinePair) (*mcp.CallToolResult, error) {
+	sh := findSheetByID(sheets, sheetID)
 	if sh == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetIDArg)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
-
 	var parent *xmind.Topic
-	if parentIDArg == "" {
+	if parentID == "" {
 		parent = &sh.RootTopic
 	} else {
-		parent = findTopicByID(&sh.RootTopic, parentIDArg)
+		parent = findTopicByID(&sh.RootTopic, parentID)
 		if parent == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentIDArg)), nil
+			return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
 		}
 	}
-
 	forest := buildOutlineForest(pairs)
 	ch := ensureChildren(parent)
 	total := 0
-	for _, root := range forest {
-		t := outlineNodeToTopics(root)
+	for _, r := range forest {
+		t := outlineNodeToTopics(r)
 		ch.Attached = append(ch.Attached, t)
 		total += countTopics(&t)
 	}
@@ -217,32 +252,78 @@ func (h *XMindHandler) ImportFromOutline(ctx context.Context, req mcp.CallToolRe
 	return textResult(fmt.Sprintf("imported %d topics", total)), nil
 }
 
-func parseOutlineToPairs(outline string) []outlinePair {
-	lines := strings.Split(outline, "\n")
-	var firstNonEmpty string
-	var firstIdx int
+func firstNonEmptyLineIndex(lines []string) (idx int, ok bool) {
 	for i, line := range lines {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		firstNonEmpty = line
-		firstIdx = i
-		break
+		return i, true
 	}
-	if firstNonEmpty == "" {
-		return nil
-	}
+	return 0, false
+}
 
-	trimmedFirst := strings.TrimLeft(firstNonEmpty, " \t")
-	var mode string // heading, list, plain
+func detectOutlineMode(trimmedFirst string) string {
 	switch {
 	case strings.HasPrefix(trimmedFirst, "#"):
-		mode = "heading"
+		return "heading"
 	case strings.HasPrefix(trimmedFirst, "-") || strings.HasPrefix(trimmedFirst, "*"):
-		mode = "list"
+		return "list"
 	default:
-		mode = "plain"
+		return "plain"
 	}
+}
+
+func headingHashPrefixLen(s string) int {
+	n := 0
+	for n < len(s) && s[n] == '#' {
+		n++
+	}
+	return n
+}
+
+func appendOutlinePairHeading(line string, pairs *[]outlinePair) {
+	s := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(s, "#") {
+		return
+	}
+	n := headingHashPrefixLen(s)
+	if n == 0 {
+		return
+	}
+	rest := strings.TrimSpace(s[n:])
+	*pairs = append(*pairs, outlinePair{depth: n - 1, title: rest})
+}
+
+func appendOutlinePairList(line string, pairs *[]outlinePair) {
+	lead := countLeadingSpaceTabs(line)
+	s := strings.TrimLeft(line, " \t")
+	var title string
+	switch {
+	case strings.HasPrefix(s, "- "):
+		title = strings.TrimSpace(s[2:])
+	case strings.HasPrefix(s, "* "):
+		title = strings.TrimSpace(s[2:])
+	case s == "-" || s == "*":
+		title = ""
+	default:
+		return
+	}
+	*pairs = append(*pairs, outlinePair{depth: lead / 2, title: title})
+}
+
+func appendOutlinePairPlain(line string, pairs *[]outlinePair) {
+	lead := countLeadingSpaceTabs(line)
+	title := strings.TrimSpace(line)
+	*pairs = append(*pairs, outlinePair{depth: lead / 2, title: title})
+}
+
+func parseOutlineToPairs(outline string) []outlinePair {
+	lines := strings.Split(outline, "\n")
+	firstIdx, ok := firstNonEmptyLineIndex(lines)
+	if !ok {
+		return nil
+	}
+	mode := detectOutlineMode(strings.TrimLeft(lines[firstIdx], " \t"))
 
 	var pairs []outlinePair
 	for _, line := range lines[firstIdx:] {
@@ -251,41 +332,11 @@ func parseOutlineToPairs(outline string) []outlinePair {
 		}
 		switch mode {
 		case "heading":
-			s := strings.TrimLeft(line, " \t")
-			if !strings.HasPrefix(s, "#") {
-				continue
-			}
-			n := 0
-			for n < len(s) && s[n] == '#' {
-				n++
-			}
-			if n == 0 {
-				continue
-			}
-			rest := strings.TrimSpace(s[n:])
-			pairs = append(pairs, outlinePair{depth: n - 1, title: rest})
+			appendOutlinePairHeading(line, &pairs)
 		case "list":
-			orig := line
-			lead := countLeadingSpaceTabs(orig)
-			s := strings.TrimLeft(orig, " \t")
-			var title string
-			switch {
-			case strings.HasPrefix(s, "- "):
-				title = strings.TrimSpace(s[2:])
-			case strings.HasPrefix(s, "* "):
-				title = strings.TrimSpace(s[2:])
-			case s == "-" || s == "*":
-				title = ""
-			default:
-				continue
-			}
-			depth := lead / 2
-			pairs = append(pairs, outlinePair{depth: depth, title: title})
+			appendOutlinePairList(line, &pairs)
 		case "plain":
-			lead := countLeadingSpaceTabs(line)
-			depth := lead / 2
-			title := strings.TrimSpace(line)
-			pairs = append(pairs, outlinePair{depth: depth, title: title})
+			appendOutlinePairPlain(line, &pairs)
 		}
 	}
 	return pairs

--- a/internal/xmind/json_codec.go
+++ b/internal/xmind/json_codec.go
@@ -50,6 +50,12 @@ func jsonValueIsPresent(raw json.RawMessage) bool {
 	return len(raw) > 0 && !bytes.Equal(raw, []byte("null"))
 }
 
+func unmarshalFieldSilent(raw map[string]json.RawMessage, key string, dst any) {
+	if v, ok := raw[key]; ok {
+		_ = json.Unmarshal(v, dst)
+	}
+}
+
 // marshalJSONNoHTMLEscape marshals v like json.Marshal but disables HTML-sensitive
 // escaping of &, <, and > so content.json matches XMind's on-disk style (literal
 // characters inside JSON strings, not \u0026 / \u003c / \u003e).
@@ -166,6 +172,32 @@ func (b *Boundary) MarshalJSON() ([]byte, error) {
 
 // --- Relationship ---
 
+func decodeRelationshipScalars(r *Relationship, raw map[string]json.RawMessage) {
+	unmarshalFieldSilent(raw, "id", &r.ID)
+	unmarshalFieldSilent(raw, "end1Id", &r.End1ID)
+	unmarshalFieldSilent(raw, "end2Id", &r.End2ID)
+	unmarshalFieldSilent(raw, "title", &r.Title)
+}
+
+func unmarshalRelationshipControlPoints(v json.RawMessage) (map[string]Position, error) {
+	var cp map[string]json.RawMessage
+	if err := json.Unmarshal(v, &cp); err != nil {
+		return nil, err
+	}
+	if len(cp) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]Position, len(cp))
+	for k, rv := range cp {
+		var p Position
+		if err := json.Unmarshal(rv, &p); err != nil {
+			return nil, err
+		}
+		out[k] = p
+	}
+	return out, nil
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (r *Relationship) UnmarshalJSON(data []byte) error {
 	raw, err := unmarshalObjectMap(data)
@@ -174,32 +206,14 @@ func (r *Relationship) UnmarshalJSON(data []byte) error {
 	}
 	ex := cloneJSONMap(raw)
 	deleteKeys(ex, "id", "end1Id", "end2Id", "title", "controlPoints")
-	if v, ok := raw["id"]; ok {
-		_ = json.Unmarshal(v, &r.ID)
-	}
-	if v, ok := raw["end1Id"]; ok {
-		_ = json.Unmarshal(v, &r.End1ID)
-	}
-	if v, ok := raw["end2Id"]; ok {
-		_ = json.Unmarshal(v, &r.End2ID)
-	}
-	if v, ok := raw["title"]; ok {
-		_ = json.Unmarshal(v, &r.Title)
-	}
+	decodeRelationshipScalars(r, raw)
 	if v, ok := raw["controlPoints"]; ok {
-		var cp map[string]json.RawMessage
-		if err := json.Unmarshal(v, &cp); err != nil {
-			return err
+		cp, errCP := unmarshalRelationshipControlPoints(v)
+		if errCP != nil {
+			return errCP
 		}
-		if len(cp) > 0 {
-			r.ControlPoints = make(map[string]Position, len(cp))
-			for k, rv := range cp {
-				var p Position
-				if err := json.Unmarshal(rv, &p); err != nil {
-					return err
-				}
-				r.ControlPoints[k] = p
-			}
+		if cp != nil {
+			r.ControlPoints = cp
 		}
 	}
 	r.extra = ex
@@ -329,6 +343,73 @@ var topicKnownKeys = []string{
 
 // --- Topic ---
 
+func unmarshalTopicOptionalImage(t *Topic, raw map[string]json.RawMessage) error {
+	v, ok := raw["image"]
+	if !ok || !jsonValueIsPresent(v) {
+		return nil
+	}
+	var img TopicImage
+	if err := json.Unmarshal(v, &img); err != nil {
+		return err
+	}
+	t.Image = &img
+	return nil
+}
+
+func unmarshalTopicOptionalNotes(t *Topic, raw map[string]json.RawMessage) error {
+	v, ok := raw["notes"]
+	if !ok || !jsonValueIsPresent(v) {
+		return nil
+	}
+	var n Notes
+	if err := json.Unmarshal(v, &n); err != nil {
+		return err
+	}
+	t.Notes = &n
+	return nil
+}
+
+func unmarshalTopicOptionalChildren(t *Topic, raw map[string]json.RawMessage) error {
+	v, ok := raw["children"]
+	if !ok || !jsonValueIsPresent(v) {
+		return nil
+	}
+	var ch Children
+	if err := json.Unmarshal(v, &ch); err != nil {
+		return err
+	}
+	t.Children = &ch
+	return nil
+}
+
+func unmarshalTopicOptionalPosition(t *Topic, raw map[string]json.RawMessage) error {
+	v, ok := raw["position"]
+	if !ok || !jsonValueIsPresent(v) {
+		return nil
+	}
+	var pos Position
+	if err := json.Unmarshal(v, &pos); err != nil {
+		return err
+	}
+	t.Position = &pos
+	return nil
+}
+
+func decodeTopicSilentFields(t *Topic, raw map[string]json.RawMessage) {
+	unmarshalFieldSilent(raw, "id", &t.ID)
+	unmarshalFieldSilent(raw, "class", &t.Class)
+	unmarshalFieldSilent(raw, "title", &t.Title)
+	unmarshalFieldSilent(raw, "titleUnedited", &t.TitleUnedited)
+	unmarshalFieldSilent(raw, "attributedTitle", &t.AttributedTitle)
+	unmarshalFieldSilent(raw, "structureClass", &t.StructureClass)
+	unmarshalFieldSilent(raw, "labels", &t.Labels)
+	unmarshalFieldSilent(raw, "markers", &t.Markers)
+	unmarshalFieldSilent(raw, "href", &t.Href)
+	unmarshalFieldSilent(raw, "boundaries", &t.Boundaries)
+	unmarshalFieldSilent(raw, "extensions", &t.Extensions)
+	unmarshalFieldSilent(raw, "summaries", &t.Summaries)
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (t *Topic) UnmarshalJSON(data []byte) error {
 	raw, err := unmarshalObjectMap(data)
@@ -337,69 +418,18 @@ func (t *Topic) UnmarshalJSON(data []byte) error {
 	}
 	ex := cloneJSONMap(raw)
 	deleteKeys(ex, topicKnownKeys...)
-	if v, ok := raw["id"]; ok {
-		_ = json.Unmarshal(v, &t.ID)
+	decodeTopicSilentFields(t, raw)
+	if err := unmarshalTopicOptionalImage(t, raw); err != nil {
+		return err
 	}
-	if v, ok := raw["class"]; ok {
-		_ = json.Unmarshal(v, &t.Class)
+	if err := unmarshalTopicOptionalNotes(t, raw); err != nil {
+		return err
 	}
-	if v, ok := raw["title"]; ok {
-		_ = json.Unmarshal(v, &t.Title)
+	if err := unmarshalTopicOptionalChildren(t, raw); err != nil {
+		return err
 	}
-	if v, ok := raw["titleUnedited"]; ok {
-		_ = json.Unmarshal(v, &t.TitleUnedited)
-	}
-	if v, ok := raw["attributedTitle"]; ok {
-		_ = json.Unmarshal(v, &t.AttributedTitle)
-	}
-	if v, ok := raw["structureClass"]; ok {
-		_ = json.Unmarshal(v, &t.StructureClass)
-	}
-	if v, ok := raw["labels"]; ok {
-		_ = json.Unmarshal(v, &t.Labels)
-	}
-	if v, ok := raw["markers"]; ok {
-		_ = json.Unmarshal(v, &t.Markers)
-	}
-	if v, ok := raw["href"]; ok {
-		_ = json.Unmarshal(v, &t.Href)
-	}
-	if v, ok := raw["image"]; ok && jsonValueIsPresent(v) {
-		var img TopicImage
-		if err := json.Unmarshal(v, &img); err != nil {
-			return err
-		}
-		t.Image = &img
-	}
-	if v, ok := raw["notes"]; ok && jsonValueIsPresent(v) {
-		var n Notes
-		if err := json.Unmarshal(v, &n); err != nil {
-			return err
-		}
-		t.Notes = &n
-	}
-	if v, ok := raw["children"]; ok && jsonValueIsPresent(v) {
-		var ch Children
-		if err := json.Unmarshal(v, &ch); err != nil {
-			return err
-		}
-		t.Children = &ch
-	}
-	if v, ok := raw["boundaries"]; ok {
-		_ = json.Unmarshal(v, &t.Boundaries)
-	}
-	if v, ok := raw["extensions"]; ok {
-		_ = json.Unmarshal(v, &t.Extensions)
-	}
-	if v, ok := raw["summaries"]; ok {
-		_ = json.Unmarshal(v, &t.Summaries)
-	}
-	if v, ok := raw["position"]; ok && jsonValueIsPresent(v) {
-		var pos Position
-		if err := json.Unmarshal(v, &pos); err != nil {
-			return err
-		}
-		t.Position = &pos
+	if err := unmarshalTopicOptionalPosition(t, raw); err != nil {
+		return err
 	}
 	t.extra = ex
 	return nil
@@ -452,6 +482,29 @@ var sheetKnownKeys = []string{
 
 // --- Sheet ---
 
+func decodeSheetRootTopic(s *Sheet, v json.RawMessage) error {
+	return json.Unmarshal(v, &s.RootTopic)
+}
+
+func decodeSheetRawBlobs(s *Sheet, raw map[string]json.RawMessage) {
+	if v, ok := raw["extensions"]; ok {
+		s.Extensions = append(json.RawMessage(nil), v...)
+	}
+	if v, ok := raw["theme"]; ok {
+		s.Theme = append(json.RawMessage(nil), v...)
+	}
+}
+
+func decodeSheetScalars(s *Sheet, raw map[string]json.RawMessage) {
+	unmarshalFieldSilent(raw, "id", &s.ID)
+	unmarshalFieldSilent(raw, "revisionId", &s.RevisionID)
+	unmarshalFieldSilent(raw, "class", &s.Class)
+	unmarshalFieldSilent(raw, "title", &s.Title)
+	unmarshalFieldSilent(raw, "topicOverlapping", &s.TopicOverlapping)
+	unmarshalFieldSilent(raw, "relationships", &s.Relationships)
+	unmarshalFieldSilent(raw, "labelSortOrder", &s.LabelSortOrder)
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (s *Sheet) UnmarshalJSON(data []byte) error {
 	raw, err := unmarshalObjectMap(data)
@@ -460,37 +513,12 @@ func (s *Sheet) UnmarshalJSON(data []byte) error {
 	}
 	ex := cloneJSONMap(raw)
 	deleteKeys(ex, sheetKnownKeys...)
-	if v, ok := raw["id"]; ok {
-		_ = json.Unmarshal(v, &s.ID)
-	}
-	if v, ok := raw["revisionId"]; ok {
-		_ = json.Unmarshal(v, &s.RevisionID)
-	}
-	if v, ok := raw["class"]; ok {
-		_ = json.Unmarshal(v, &s.Class)
-	}
-	if v, ok := raw["title"]; ok {
-		_ = json.Unmarshal(v, &s.Title)
-	}
-	if v, ok := raw["topicOverlapping"]; ok {
-		_ = json.Unmarshal(v, &s.TopicOverlapping)
-	}
+	decodeSheetScalars(s, raw)
+	decodeSheetRawBlobs(s, raw)
 	if v, ok := raw["rootTopic"]; ok {
-		if err := json.Unmarshal(v, &s.RootTopic); err != nil {
+		if err := decodeSheetRootTopic(s, v); err != nil {
 			return err
 		}
-	}
-	if v, ok := raw["relationships"]; ok {
-		_ = json.Unmarshal(v, &s.Relationships)
-	}
-	if v, ok := raw["extensions"]; ok {
-		s.Extensions = append(json.RawMessage(nil), v...)
-	}
-	if v, ok := raw["theme"]; ok {
-		s.Theme = append(json.RawMessage(nil), v...)
-	}
-	if v, ok := raw["labelSortOrder"]; ok {
-		_ = json.Unmarshal(v, &s.LabelSortOrder)
 	}
 	s.extra = ex
 	return nil

--- a/internal/xmind/reader_test.go
+++ b/internal/xmind/reader_test.go
@@ -148,6 +148,50 @@ func findSheetByTitle(sheets []Sheet, title string) *Sheet {
 	return nil
 }
 
+func assertKitchenSinkSheet10Labels(t *testing.T, root *Topic) {
+	t.Helper()
+	labelTopic := findTopicByID(root, "9b558db8-cdf3-47ab-a6b0-ee688aa3ad58")
+	if labelTopic == nil || len(labelTopic.Labels) != 1 || labelTopic.Labels[0] != "foo" {
+		t.Fatalf("labels: %+v", labelTopic)
+	}
+}
+
+func assertKitchenSinkSheet10Notes(t *testing.T, root *Topic) {
+	t.Helper()
+	noteTopic := findTopicByID(root, "83785e34-fcdb-4049-8c42-15052c20d8d6")
+	if noteTopic == nil || noteTopic.Notes == nil || noteTopic.Notes.Plain == nil ||
+		!strings.HasPrefix(noteTopic.Notes.Plain.Content, "This is a simple, plain text note") {
+		t.Fatalf("notes: %+v", noteTopic)
+	}
+}
+
+func assertKitchenSinkSheet10Href(t *testing.T, root *Topic) {
+	t.Helper()
+	hrefTopic := findTopicByID(root, "e0d8096f-cc1a-4c33-bcc5-db9006481f85")
+	if hrefTopic == nil || hrefTopic.Href != "https://www.google.com" {
+		t.Fatalf("href: %+v", hrefTopic)
+	}
+}
+
+func assertKitchenSinkSheet10AudioExtension(t *testing.T, root *Topic) {
+	t.Helper()
+	audioTopic := findTopicByID(root, "9a8153a4-0ac2-4a5c-bc46-db9a0f38e47c")
+	if audioTopic == nil || len(audioTopic.Extensions) != 1 {
+		t.Fatalf("extensions count: %+v", audioTopic)
+	}
+	if audioTopic.Extensions[0].Provider != "org.xmind.ui.audionotes" || len(audioTopic.Extensions[0].ResourceRefs) != 1 {
+		t.Fatalf("audio extension: %+v", audioTopic.Extensions[0])
+	}
+}
+
+func assertKitchenSinkSheet11Markers(t *testing.T, root *Topic) {
+	t.Helper()
+	mkTopic := findTopicByID(root, "30888fa1-f425-43e3-a7ce-98d5d7db9578")
+	if mkTopic == nil || len(mkTopic.Markers) != 1 || mkTopic.Markers[0].MarkerID != "priority-1" {
+		t.Fatalf("markers: %+v", mkTopic)
+	}
+}
+
 // TestReadMapMetadataFields uses Sheet 10 (Topic Properties) and Sheet 11 (Markers) from the
 // kitchen sink — the first sheet (Mind Map) has no labeled/marker/note/href/extension samples.
 func TestReadMapMetadataFields(t *testing.T) {
@@ -159,35 +203,17 @@ func TestReadMapMetadataFields(t *testing.T) {
 	if prop == nil {
 		t.Fatal("missing Sheet 10 - Topic Properties")
 	}
-	labelTopic := findTopicByID(&prop.RootTopic, "9b558db8-cdf3-47ab-a6b0-ee688aa3ad58")
-	if labelTopic == nil || len(labelTopic.Labels) != 1 || labelTopic.Labels[0] != "foo" {
-		t.Fatalf("labels: %+v", labelTopic)
-	}
-	noteTopic := findTopicByID(&prop.RootTopic, "83785e34-fcdb-4049-8c42-15052c20d8d6")
-	if noteTopic == nil || noteTopic.Notes == nil || noteTopic.Notes.Plain == nil ||
-		!strings.HasPrefix(noteTopic.Notes.Plain.Content, "This is a simple, plain text note") {
-		t.Fatalf("notes: %+v", noteTopic)
-	}
-	hrefTopic := findTopicByID(&prop.RootTopic, "e0d8096f-cc1a-4c33-bcc5-db9006481f85")
-	if hrefTopic == nil || hrefTopic.Href != "https://www.google.com" {
-		t.Fatalf("href: %+v", hrefTopic)
-	}
-	audioTopic := findTopicByID(&prop.RootTopic, "9a8153a4-0ac2-4a5c-bc46-db9a0f38e47c")
-	if audioTopic == nil || len(audioTopic.Extensions) != 1 {
-		t.Fatalf("extensions count: %+v", audioTopic)
-	}
-	if audioTopic.Extensions[0].Provider != "org.xmind.ui.audionotes" || len(audioTopic.Extensions[0].ResourceRefs) != 1 {
-		t.Fatalf("audio extension: %+v", audioTopic.Extensions[0])
-	}
+	rt := &prop.RootTopic
+	assertKitchenSinkSheet10Labels(t, rt)
+	assertKitchenSinkSheet10Notes(t, rt)
+	assertKitchenSinkSheet10Href(t, rt)
+	assertKitchenSinkSheet10AudioExtension(t, rt)
 
 	markersSh := findSheetByTitle(sheets, "Sheet 11 - Markers")
 	if markersSh == nil {
 		t.Fatal("missing Sheet 11 - Markers")
 	}
-	mkTopic := findTopicByID(&markersSh.RootTopic, "30888fa1-f425-43e3-a7ce-98d5d7db9578")
-	if mkTopic == nil || len(mkTopic.Markers) != 1 || mkTopic.Markers[0].MarkerID != "priority-1" {
-		t.Fatalf("markers: %+v", mkTopic)
-	}
+	assertKitchenSinkSheet11Markers(t, &markersSh.RootTopic)
 }
 
 func TestReadMapRelationships(t *testing.T) {
@@ -272,6 +298,33 @@ func TestReadMapDoesNotModifyKitchenSink(t *testing.T) {
 	}
 }
 
+func assertRoundTripRootTitlesMatch(t *testing.T, sheets1, sheets2 []Sheet) {
+	t.Helper()
+	if len(sheets2) != len(sheets1) {
+		t.Fatalf("sheet count after write: got %d want %d", len(sheets2), len(sheets1))
+	}
+	for i := range sheets1 {
+		if sheets2[i].RootTopic.Title != sheets1[i].RootTopic.Title {
+			t.Fatalf("sheet %d root title: got %q want %q", i, sheets2[i].RootTopic.Title, sheets1[i].RootTopic.Title)
+		}
+	}
+}
+
+func assertMarshaledSheetsEqual(t *testing.T, sheets1, sheets2 []Sheet) {
+	t.Helper()
+	b1, err := json.Marshal(sheets1)
+	if err != nil {
+		t.Fatalf("marshal sheets1: %v", err)
+	}
+	b2, err := json.Marshal(sheets2)
+	if err != nil {
+		t.Fatalf("marshal sheets2: %v", err)
+	}
+	if !bytes.Equal(b1, b2) {
+		t.Fatalf("round-trip JSON mismatch (len %d vs %d)", len(b1), len(b2))
+	}
+}
+
 func TestWriteMapRoundTrip(t *testing.T) {
 	src := kitchenSinkPath(t)
 	dir := t.TempDir()
@@ -296,27 +349,8 @@ func TestWriteMapRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMap after write: %v", err)
 	}
-	if len(sheets2) != len(sheets1) {
-		t.Fatalf("sheet count after write: got %d want %d", len(sheets2), len(sheets1))
-	}
-
-	for i := range sheets1 {
-		if sheets2[i].RootTopic.Title != sheets1[i].RootTopic.Title {
-			t.Fatalf("sheet %d root title: got %q want %q", i, sheets2[i].RootTopic.Title, sheets1[i].RootTopic.Title)
-		}
-	}
-
-	b1, err := json.Marshal(sheets1)
-	if err != nil {
-		t.Fatalf("marshal sheets1: %v", err)
-	}
-	b2, err := json.Marshal(sheets2)
-	if err != nil {
-		t.Fatalf("marshal sheets2: %v", err)
-	}
-	if !bytes.Equal(b1, b2) {
-		t.Fatalf("round-trip JSON mismatch (len %d vs %d)", len(b1), len(b2))
-	}
+	assertRoundTripRootTitlesMatch(t, sheets1, sheets2)
+	assertMarshaledSheetsEqual(t, sheets1, sheets2)
 }
 
 func copyFile(src, dst string) error {

--- a/internal/xmind/writer.go
+++ b/internal/xmind/writer.go
@@ -24,24 +24,124 @@ const metadataJSON = `{"dataStructureVersion":"2","creator":{"name":"xmind-mcp",
 
 const manifestJSON = `{"file-entries":{"content.json":{},"metadata.json":{},"content.xml":{}}}`
 
+// openZipReaderAtPath opens path as a zip and returns a reader; the caller must close the file.
+func openZipReaderAtPath(path string) (*zip.Reader, *os.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open xmind file: %w", err)
+	}
+	st, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("stat xmind file: %w", err)
+	}
+	zr, err := zip.NewReader(f, st.Size())
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("read zip: %w", err)
+	}
+	return zr, f, nil
+}
+
+// copyZipEntryRaw copies one entry from an existing zip into zw using raw compressed bytes.
+// The caller must skip entries (e.g. content.json) that should not be copied verbatim.
+func copyZipEntryRaw(zw *zip.Writer, src *zip.File) error {
+	fh := src.FileHeader
+	if len(fh.Extra) > 0 {
+		fh.Extra = append([]byte(nil), fh.Extra...)
+	}
+	dst, err := zw.CreateRaw(&fh)
+	if err != nil {
+		return fmt.Errorf("zip create raw %q: %w", src.Name, err)
+	}
+	raw, err := src.OpenRaw()
+	if err != nil {
+		return fmt.Errorf("zip open raw %q: %w", src.Name, err)
+	}
+	if _, err := io.Copy(dst, raw); err != nil {
+		if closer, ok := raw.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		return fmt.Errorf("copy zip entry %q: %w", src.Name, err)
+	}
+	if closer, ok := raw.(io.Closer); ok {
+		_ = closer.Close()
+	}
+	return nil
+}
+
+func copyZipEntriesExceptContentJSON(zw *zip.Writer, zr *zip.Reader) error {
+	for _, src := range zr.File {
+		if src.Name == "content.json" {
+			continue
+		}
+		if err := copyZipEntryRaw(zw, src); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeZipBytes(zw *zip.Writer, name string, body []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("zip create %q: %w", name, err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("zip write %q: %w", name, err)
+	}
+	return nil
+}
+
+func writeNewMapStandardEntries(zw *zip.Writer, contentJSON []byte) error {
+	entries := []struct {
+		name string
+		body []byte
+	}{
+		{"content.json", contentJSON},
+		{"metadata.json", []byte(metadataJSON)},
+		{"content.xml", stubContentXML},
+		{"manifest.json", []byte(manifestJSON)},
+	}
+	for _, e := range entries {
+		if err := writeZipBytes(zw, e.name, e.body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func abortZipWriterAndFile(zw *zip.Writer, tmp *os.File) {
+	_ = zw.Close()
+	_ = tmp.Close()
+}
+
+func finishZipTempFile(zw *zip.Writer, tmp *os.File, tmpPath, dst string) error {
+	if err := zw.Close(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("close zip writer: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := replaceTempFile(tmpPath, dst); err != nil {
+		return err
+	}
+	return nil
+}
+
 // WriteMap replaces content.json in an existing .xmind zip, preserving all other entries
 // via raw compressed-byte copy (OpenRaw / CreateRaw).
 func WriteMap(path string, sheets []Sheet) error {
-	oldFile, err := os.Open(path)
+	oldZR, oldFile, err := openZipReaderAtPath(path)
 	if err != nil {
-		return fmt.Errorf("open xmind file: %w", err)
+		return err
 	}
 	defer func() { _ = oldFile.Close() }()
-
-	st, err := oldFile.Stat()
-	if err != nil {
-		return fmt.Errorf("stat xmind file: %w", err)
-	}
-
-	oldZR, err := zip.NewReader(oldFile, st.Size())
-	if err != nil {
-		return fmt.Errorf("read zip: %w", err)
-	}
 
 	data, err := marshalSheetsForContentJSON(sheets)
 	if err != nil {
@@ -63,64 +163,17 @@ func WriteMap(path string, sheets []Sheet) error {
 
 	zw := zip.NewWriter(tmp)
 
-	for _, src := range oldZR.File {
-		if src.Name == "content.json" {
-			continue
-		}
-		fh := src.FileHeader
-		if len(fh.Extra) > 0 {
-			fh.Extra = append([]byte(nil), fh.Extra...)
-		}
-		dst, err := zw.CreateRaw(&fh)
-		if err != nil {
-			_ = zw.Close()
-			_ = tmp.Close()
-			return fmt.Errorf("zip create raw %q: %w", src.Name, err)
-		}
-		raw, err := src.OpenRaw()
-		if err != nil {
-			_ = zw.Close()
-			_ = tmp.Close()
-			return fmt.Errorf("zip open raw %q: %w", src.Name, err)
-		}
-		if _, err := io.Copy(dst, raw); err != nil {
-			if closer, ok := raw.(io.Closer); ok {
-				_ = closer.Close()
-			}
-			_ = zw.Close()
-			_ = tmp.Close()
-			return fmt.Errorf("copy zip entry %q: %w", src.Name, err)
-		}
-		if closer, ok := raw.(io.Closer); ok {
-			_ = closer.Close()
-		}
+	if err := copyZipEntriesExceptContentJSON(zw, oldZR); err != nil {
+		abortZipWriterAndFile(zw, tmp)
+		return err
 	}
 
-	cw, err := zw.Create("content.json")
-	if err != nil {
-		_ = zw.Close()
-		_ = tmp.Close()
-		return fmt.Errorf("zip create content.json: %w", err)
-	}
-	if _, err := cw.Write(data); err != nil {
-		_ = zw.Close()
-		_ = tmp.Close()
-		return fmt.Errorf("write content.json: %w", err)
+	if err := writeZipBytes(zw, "content.json", data); err != nil {
+		abortZipWriterAndFile(zw, tmp)
+		return err
 	}
 
-	if err := zw.Close(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("close zip writer: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("sync temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp file: %w", err)
-	}
-
-	if err := replaceTempFile(tmpPath, path); err != nil {
+	if err := finishZipTempFile(zw, tmp, tmpPath, path); err != nil {
 		return err
 	}
 	committed = true
@@ -150,51 +203,12 @@ func CreateNewMap(path string, sheets []Sheet) error {
 
 	zw := zip.NewWriter(tmp)
 
-	writeEntry := func(name string, body []byte) error {
-		w, err := zw.Create(name)
-		if err != nil {
-			return fmt.Errorf("zip create %q: %w", name, err)
-		}
-		if _, err := w.Write(body); err != nil {
-			return fmt.Errorf("zip write %q: %w", name, err)
-		}
-		return nil
-	}
-
-	if err := writeEntry("content.json", data); err != nil {
-		_ = zw.Close()
-		_ = tmp.Close()
-		return err
-	}
-	if err := writeEntry("metadata.json", []byte(metadataJSON)); err != nil {
-		_ = zw.Close()
-		_ = tmp.Close()
-		return err
-	}
-	if err := writeEntry("content.xml", stubContentXML); err != nil {
-		_ = zw.Close()
-		_ = tmp.Close()
-		return err
-	}
-	if err := writeEntry("manifest.json", []byte(manifestJSON)); err != nil {
-		_ = zw.Close()
-		_ = tmp.Close()
+	if err := writeNewMapStandardEntries(zw, data); err != nil {
+		abortZipWriterAndFile(zw, tmp)
 		return err
 	}
 
-	if err := zw.Close(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("close zip writer: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("sync temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp file: %w", err)
-	}
-
-	if err := replaceTempFile(tmpPath, path); err != nil {
+	if err := finishZipTempFile(zw, tmp, tmpPath, path); err != nil {
 		return err
 	}
 	committed = true

--- a/internal/xmind/writer_test.go
+++ b/internal/xmind/writer_test.go
@@ -146,29 +146,13 @@ func TestWriteMapAtomicSafetyOnFailure(t *testing.T) {
 	}
 }
 
-func TestCreateNewMapFileStructure(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "new.xmind")
-	sh := Sheet{
-		ID:               uuid.New().String(),
-		RevisionID:       uuid.New().String(),
-		Class:            "sheet",
-		Title:            "S1",
-		TopicOverlapping: "overlap",
-		RootTopic: Topic{
-			ID:             uuid.New().String(),
-			Class:          "topic",
-			Title:          "Root",
-			StructureClass: "org.xmind.ui.map.clockwise",
-		},
-	}
-	if err := CreateNewMap(path, []Sheet{sh}); err != nil {
-		t.Fatal(err)
-	}
+func openZipReader(t *testing.T, path string) *zip.Reader {
+	t.Helper()
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = f.Close() }()
+	t.Cleanup(func() { _ = f.Close() })
 	st, err := f.Stat()
 	if err != nil {
 		t.Fatal(err)
@@ -177,6 +161,11 @@ func TestCreateNewMapFileStructure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return zr
+}
+
+func assertZipHasCoreEntries(t *testing.T, zr *zip.Reader) {
+	t.Helper()
 	want := map[string]struct{}{
 		"content.json":  {},
 		"metadata.json": {},
@@ -192,6 +181,10 @@ func TestCreateNewMapFileStructure(t *testing.T) {
 			t.Fatalf("missing zip entry %q, have %v", name, got)
 		}
 	}
+}
+
+func assertMetadataCreatorName(t *testing.T, zr *zip.Reader, want string) {
+	t.Helper()
 	var metaEntry *zip.File
 	for i := range zr.File {
 		if zr.File[i].Name == "metadata.json" {
@@ -219,9 +212,32 @@ func TestCreateNewMapFileStructure(t *testing.T) {
 	if err := json.Unmarshal(metaBytes, &meta); err != nil {
 		t.Fatalf("metadata.json: %v", err)
 	}
-	if meta.Creator.Name != "xmind-mcp" {
-		t.Fatalf("creator.name: got %q want xmind-mcp", meta.Creator.Name)
+	if meta.Creator.Name != want {
+		t.Fatalf("creator.name: got %q want %q", meta.Creator.Name, want)
 	}
+}
+
+func TestCreateNewMapFileStructure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "new.xmind")
+	sh := Sheet{
+		ID:               uuid.New().String(),
+		RevisionID:       uuid.New().String(),
+		Class:            "sheet",
+		Title:            "S1",
+		TopicOverlapping: "overlap",
+		RootTopic: Topic{
+			ID:             uuid.New().String(),
+			Class:          "topic",
+			Title:          "Root",
+			StructureClass: "org.xmind.ui.map.clockwise",
+		},
+	}
+	if err := CreateNewMap(path, []Sheet{sh}); err != nil {
+		t.Fatal(err)
+	}
+	zr := openZipReader(t, path)
+	assertZipHasCoreEntries(t, zr)
+	assertMetadataCreatorName(t, zr, "xmind-mcp")
 }
 
 func TestCreateNewMapReadBack(t *testing.T) {


### PR DESCRIPTION
## Summary

This branch refactors the codebase so more functions stay **below the project’s gocyclo threshold** (`-over 10`). Changes are **structural**: smaller helpers, clearer control flow, and test splits. **MCP tool behavior and JSON shapes are intended to stay the same**, except for one small cleanup (unused parameter removal in move-topic validation).

## Motivation

Several entrypoints in `internal/xmind`, handler code, and tests had grown branchy enough to trip `make cyclo` and were harder to reason about. The work breaks those paths into focused helpers without changing the public I/O and handler APIs.

## What changed (by area)

- **`internal/xmind/json_codec.go`** — Split `UnmarshalJSON` for Topic, Sheet, and Relationship into private helpers (`unmarshalFieldSilent`, scalar/raw blobs, relationship `controlPoints`, etc.).
- **`internal/xmind/writer.go`** — Factored zip open, raw entry copy, new-map standard entries, temp-file finish/abort, and related helpers; rewired `WriteMap` / `CreateNewMap`.
- **`internal/server/handler/utils.go`** — Outline import/export and `FindAndReplace` decomposed into smaller functions; shared “finish” paths for find-and-replace.
- **`internal/server/handler/find.go`** — Thinner handlers; helpers for subtree search, topic find, and topic-properties responses.
- **`internal/server/handler/mutate.go`** — Large refactor: topic properties (`applyTopicPropertiesArgs`, bulk IDs), summaries, boundaries, relationships, reorder/move/delete trees, and shared arg validators.
- **`internal/server/handler/sheets.go`** — Relationship listing split out; shared string validation for `AddSheet`.
- **`internal/server/handler/handler.go`** — New traversal helpers (`findDirectChildInLists`, `searchChildrenForParent`) used by tree operations; documented in **`AGENTS.md`**.
- **Tests** — `*_test.go` refactors and shared test helpers so test functions also meet the cyclo threshold; assertions preserved as behavioral checks.
- **`validateMoveTopicPreconditions`** — Removed an unused second topic argument; call site updated accordingly.