### PR TITLE
Add goreleaser for tagged binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+/dist/
 .xmind-tmp-*
 coverage.out
 coverage.html

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+version: 2
+
+builds:
+  - main: ./cmd/xmind-mcp
+    binary: xmind-mcp
+    ldflags:
+      - -X github.com/mab-go/xmind-mcp/internal/version.Version={{.Version}}
+      - -X github.com/mab-go/xmind-mcp/internal/version.Commit={{.FullCommit}}
+      - -X github.com/mab-go/xmind-mcp/internal/version.Date={{.Date}}
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,12 @@ This file is the authoritative briefing for any AI agent working on this project
 Dockerfile                — multi-stage image (Alpine build, distroless runtime)
 CLAUDE.md                 — symlink → AGENTS.md (Claude Code auto-loads this)
 .dockerignore             — Docker build context exclusions
+.goreleaser.yaml          — goreleaser config; cross-builds Linux/Windows archives on `v*` tags
 .github/
   workflows/
     ci.yml                — test, lint, and cyclomatic-complexity report artifact on push and PR
     docker-publish.yml    — multi-platform image build and push to GHCR
+    release.yml           — goreleaser release on `v*` tag push (binaries to GitHub Releases)
 cmd/
   xmind-mcp/
     main.go               — cobra command; calls server.RunStdioServer()

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The binary is written to `./bin/xmind-mcp` with version metadata from
 > **Note:** A multi-platform container image is published to
 > [GHCR](https://github.com/mab-go/xmind-mcp/pkgs/container/xmind-mcp) on
 > each push to `main` and on version tags (see **Docker** below). Pre-built
-> release binaries for all platforms may follow in a future release.
+> binaries for Linux and Windows are attached to each tagged
+> [GitHub Release](https://github.com/mab-go/xmind-mcp/releases).
 
 ------------------------------------------------------------------------
 
@@ -187,11 +188,11 @@ Use these to resolve topic ids and titles before editing a specific branch
 of the tree. Some write tools instead need sheet-level ids or ids from
 `xmind_list_relationships`—see each tool's description.
 
-| Tool                         | Description                                                                                                                               |
-|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `xmind_get_subtree`          | Return the full topic hierarchy rooted at a given topic (or the whole sheet).                                                             |
-| `xmind_get_topic_properties` | Return one topic's metadata as JSON (notes, markers, boundaries, sheet relationships for that topic, child counts); use to verify writes. |
-| `xmind_search_topics`        | Search for topics by keyword; returns matches with IDs, ancestryPath (titles from sheet root to parent of match, or null at sheet root), parent title, depth, and sheet fields when searching all sheets. |
+| Tool                         | Description                                                                                                                                                                                                        |
+|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `xmind_get_subtree`          | Return the full topic hierarchy rooted at a given topic (or the whole sheet).                                                                                                                                      |
+| `xmind_get_topic_properties` | Return one topic's metadata as JSON (notes, markers, boundaries, sheet relationships for that topic, child counts); use to verify writes.                                                                          |
+| `xmind_search_topics`        | Search for topics by keyword; returns matches with IDs, ancestryPath (titles from sheet root to parent of match, or null at sheet root), parent title, depth, and sheet fields when searching all sheets.          |
 | `xmind_find_topic`           | Find a single topic by exact title; returns ID, ancestryPath (sheet-root chain to parent of match; null at sheet root; not relative to parent_id scope), plus parent/sibling context relative to the search scope. |
 
 ### Tier 3: Topic Mutations


### PR DESCRIPTION
Mirror the goreleaser setup recently adopted in the sibling trello-mcp project so that pushing a `v*` tag produces Linux and Windows binary archives attached to the GitHub Release. Runs in parallel with the existing `docker-publish.yml`; no changes to local build flow.

Changes:
- Add `.goreleaser.yaml`: cross-builds linux/windows + amd64/arm64 (no windows/arm64), tar.gz/zip archives, ldflags into `internal/version`, changelog excludes `docs:`/`test:`/`ci:`.
- Add `.github/workflows/release.yml` triggered on `v*` tags.
- Ignore goreleaser's `/dist/` output directory.
- Update the README install note to point at the GitHub Releases page.
- Record the two new files in the AGENTS.md project tree.