### PR TITLE
Preserve unknown keys on a sheet's root topic

### DIFF
--- a/internal/xmind/json_codec.go
+++ b/internal/xmind/json_codec.go
@@ -532,7 +532,7 @@ func (s *Sheet) MarshalJSON() ([]byte, error) {
 		Class            string          `json:"class"`
 		Title            string          `json:"title"`
 		TopicOverlapping string          `json:"topicOverlapping,omitempty"`
-		RootTopic        Topic           `json:"rootTopic"`
+		RootTopic        *Topic          `json:"rootTopic"`
 		Relationships    []Relationship  `json:"relationships,omitempty"`
 		Extensions       json.RawMessage `json:"extensions,omitempty"`
 		Theme            json.RawMessage `json:"theme,omitempty"`
@@ -543,7 +543,7 @@ func (s *Sheet) MarshalJSON() ([]byte, error) {
 		Class:            s.Class,
 		Title:            s.Title,
 		TopicOverlapping: s.TopicOverlapping,
-		RootTopic:        s.RootTopic,
+		RootTopic:        &s.RootTopic,
 		Relationships:    s.Relationships,
 		Extensions:       s.Extensions,
 		Theme:            s.Theme,

--- a/internal/xmind/json_codec_test.go
+++ b/internal/xmind/json_codec_test.go
@@ -133,7 +133,7 @@ func TestChildrenPreservesUnknownBucket(t *testing.T) {
 	}
 }
 
-// TestWriteMapZipRoundTripPreservesSheetExtra checks ReadMap → WriteMap → ReadMap keeps bag keys on a sheet.
+// TestWriteMapZipRoundTripPreservesSheetExtra checks a ReadMap -> WriteMap -> ReadMap cycle keeps bag keys on a sheet.
 func TestWriteMapZipRoundTripPreservesSheetExtra(t *testing.T) {
 	src := kitchenSinkPath(t)
 	dir := t.TempDir()
@@ -165,5 +165,108 @@ func TestWriteMapZipRoundTripPreservesSheetExtra(t *testing.T) {
 	}
 	if !bytes.Contains(raw, []byte("roundTrip")) {
 		t.Fatalf("unexpected preserved value: %s", raw)
+	}
+}
+
+// TestSheetMarshalPreservesRootTopicUnknownKeys verifies that unknown keys on a
+// sheet's rootTopic survive Sheet.MarshalJSON, identically to keys on child topics.
+// Sheet.MarshalJSON must marshal the root topic through (*Topic).MarshalJSON so its
+// preserved extra bag is merged back rather than dropped.
+func TestSheetMarshalPreservesRootTopicUnknownKeys(t *testing.T) {
+	const in = `{"id":"s1","class":"sheet","title":"S",
+		"rootTopic":{"id":"r","class":"topic","title":"R","customRootKey":{"foo":1}}}`
+	var sh Sheet
+	if err := json.Unmarshal([]byte(in), &sh); err != nil {
+		t.Fatal(err)
+	}
+	out, err := json.Marshal(&sh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top struct {
+		RootTopic map[string]json.RawMessage `json:"rootTopic"`
+	}
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := top.RootTopic["customRootKey"]; !ok {
+		t.Fatalf("missing customRootKey on rootTopic after marshal: %s", out)
+	}
+}
+
+// readKitchenSinkCopy copies the kitchen-sink fixture into a fresh temp file named name
+// and returns the parsed sheets together with the temp path for write-back.
+func readKitchenSinkCopy(t *testing.T, name string) ([]Sheet, string) {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), name)
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+	sheets, err := ReadMap(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sheets) == 0 {
+		t.Fatal("no sheets")
+	}
+	return sheets, dst
+}
+
+// TestWriteMapZipRoundTripPreservesRootTopicExtra checks that a ReadMap -> WriteMap ->
+// ReadMap cycle keeps preserved (unknown) keys on a sheet's root topic.
+func TestWriteMapZipRoundTripPreservesRootTopicExtra(t *testing.T) {
+	sheets, dst := readKitchenSinkCopy(t, "preserve-root.xmind")
+	key := "_xmindMcpRootPreserveTest"
+	sheets[0].RootTopic.extra = map[string]json.RawMessage{
+		key: json.RawMessage(`{"roundTrip":true}`),
+	}
+	if err := WriteMap(dst, sheets); err != nil {
+		t.Fatal(err)
+	}
+	sheets2, err := ReadMap(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, ok := sheets2[0].RootTopic.extra[key]
+	if !ok {
+		t.Fatalf("root topic extra key %q missing after zip round-trip", key)
+	}
+	if !bytes.Contains(raw, []byte("roundTrip")) {
+		t.Fatalf("unexpected preserved value: %s", raw)
+	}
+}
+
+// TestWriteMapZipRoundTripRootAndChildExtraParity verifies that the unknown-key
+// fidelity guarantee is not position-dependent: preserved keys survive a ReadMap ->
+// WriteMap -> ReadMap cycle on both the root topic and a child topic. The two assertions
+// use t.Errorf (not t.Fatalf) so a failure on one does not hide the result of the other.
+func TestWriteMapZipRoundTripRootAndChildExtraParity(t *testing.T) {
+	sheets, dst := readKitchenSinkCopy(t, "parity.xmind")
+	root := &sheets[0].RootTopic
+	if root.Children == nil || len(root.Children.Attached) == 0 {
+		t.Fatal("expected root topic to have at least one attached child")
+	}
+	const rootKey = "_xmindMcpRootParity"
+	const childKey = "_xmindMcpChildParity"
+	root.extra = map[string]json.RawMessage{rootKey: json.RawMessage(`{"at":"root"}`)}
+	root.Children.Attached[0].extra = map[string]json.RawMessage{
+		childKey: json.RawMessage(`{"at":"child"}`),
+	}
+	if err := WriteMap(dst, sheets); err != nil {
+		t.Fatal(err)
+	}
+	sheets2, err := ReadMap(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root2 := &sheets2[0].RootTopic
+	if _, ok := root2.extra[rootKey]; !ok {
+		t.Errorf("root topic extra key %q dropped after round-trip", rootKey)
+	}
+	if root2.Children == nil || len(root2.Children.Attached) == 0 {
+		t.Fatal("attached children lost after round-trip")
+	}
+	if _, ok := root2.Children.Attached[0].extra[childKey]; !ok {
+		t.Errorf("child topic extra key %q dropped after round-trip", childKey)
 	}
 }


### PR DESCRIPTION
`Sheet.MarshalJSON` placed the root topic in its aux struct by value, so `encoding/json` could not take its address to invoke the pointer-receiver `(*Topic).MarshalJSON`. It fell back to default struct marshaling, which silently drops the unexported `extra` bag that preserves unknown/forward-compat keys. Child topics were unaffected because they live in addressable slice elements, making the `content.json` fidelity guarantee position-dependent.

Changes:
- Hold the root topic as `*Topic` in `Sheet.MarshalJSON` and assign `&s.RootTopic` so `(*Topic).MarshalJSON` runs for it
- Add tests covering the marshal path and the full ReadMap -> WriteMap -> ReadMap cycle for root-topic keys
- Add a parity test asserting root and child topics preserve unknown keys identically
- Extract a `readKitchenSinkCopy` test helper to share fixture setup

Closes #40