### PR TITLE
Add code coverage tracking via Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -20,7 +21,12 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: go build ./...
-      - run: go test -race ./...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+      - uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage.out
+          fail_ci_if_error: true
 
   lint:
     name: lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ Dockerfile                — multi-stage image (Alpine build, distroless runtim
 CLAUDE.md                 — symlink → AGENTS.md (Claude Code auto-loads this)
 .dockerignore             — Docker build context exclusions
 .goreleaser.yaml          — goreleaser config; cross-builds Linux/Windows archives on `v*` tags
+codecov.yml               — Codecov config; informational (non-blocking) project & patch coverage
 .github/
   workflows/
-    ci.yml                — test, lint, and cyclomatic-complexity report artifact on push and PR
+    ci.yml                — test (+ coverage upload to Codecov), lint, and cyclomatic-complexity report artifact on push and PR
     docker-publish.yml    — multi-platform image build and push to GHCR
     release.yml           — goreleaser release on `v*` tag push (binaries to GitHub Releases)
 cmd/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/mab-go/xmind-mcp/actions"><img src="https://img.shields.io/github/check-runs/mab-go/xmind-mcp/main?style=flat&labelColor=555555&label=checks" alt="Build Status" /></a>
+  <a href="https://codecov.io/gh/mab-go/xmind-mcp"><img src="https://img.shields.io/codecov/c/github/mab-go/xmind-mcp?style=flat&logo=codecov&logoColor=white&labelColor=555555" alt="Code Coverage" /></a>
   <a href="https://goreportcard.com/report/github.com/mab-go/xmind-mcp"><img src="https://goreportcard.com/badge/github.com/mab-go/xmind-mcp" alt="Go Report Card" /></a>
   <a href="https://pkg.go.dev/github.com/mab-go/xmind-mcp"><img src="https://img.shields.io/badge/-reference-00ADD8?style=flat&logo=go&logoColor=white&labelColor=555555" alt="Go Reference" /></a>
   <a href="https://deepwiki.com/mab-go/xmind-mcp"><img src="https://img.shields.io/badge/DeepWiki-xmind--mcp-blue?style=flat&logoColor=white&labelColor=555555" alt="Ask DeepWiki"></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Brings xmind-mcp to parity with the sibling repos mab-go/nmea and mab-go/trello-mcp by collecting test coverage in CI and reporting it to Codecov. Coverage is informational only and never blocks CI.

Changes:
- Collect coverage in the `test` job (`-coverprofile=coverage.out -covermode=atomic`) and upload via `codecov/codecov-action@v5` using OIDC; add `id-token: write` permission
- Add `codecov.yml` with non-blocking `informational` project and patch status checks
- Add a Code Coverage badge to the README badge row
- Note `codecov.yml` and the coverage upload in the `AGENTS.md` project structure

Closes #32