### PR TITLE
Preserve unknown keys on Notes and NoteContent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,15 +105,15 @@ Every mutating tool call follows this exact pattern — do not deviate from it:
 
 ### `content.json` fidelity (unknown keys)
 
-Major JSON object types in the workbook tree use custom `MarshalJSON` / `UnmarshalJSON` in **`internal/xmind/json_codec.go`**. Unknown keys on those objects are stored in an unexported `extra` field (`json:"-"` on the struct) and merged back on marshal so XMind-specific or forward-compatible properties survive a read → edit → write cycle.
+Major JSON object types in the workbook tree use custom `MarshalJSON` / `UnmarshalJSON` in **`internal/xmind/json_codec.go`**. Unknown keys on those objects are stored in an unexported `extra` field (a `map[string]json.RawMessage` with no JSON tag; the custom marshaler never reflects over the struct directly) and merged back on marshal so XMind-specific or forward-compatible properties survive a read → edit → write cycle.
 
-When you add a **new first-class field** to `Sheet`, `Topic`, `Children`, `Relationship`, `Boundary`, the summary-range `Summary`, `Marker`, `Position`, `TopicImage`, or `AttributedTitleItem`, you **must** add the JSON key to the corresponding allowlist in `json_codec.go` (e.g. `topicKnownKeys`, `sheetKnownKeys`, or the `deleteKeys(...)` list for that type). Otherwise the new field will be treated as opaque preserved data and will not populate the typed field.
+When you add a **new first-class field** to `Sheet`, `Topic`, `Children`, `Relationship`, `Boundary`, the summary-range `Summary`, `Marker`, `Position`, `TopicImage`, `AttributedTitleItem`, `Notes`, or `NoteContent`, you **must** add the JSON key to the corresponding allowlist in `json_codec.go` (e.g. `topicKnownKeys`, `sheetKnownKeys`, or the `deleteKeys(...)` list for that type — `Notes` uses `"plain"`/`"realHTML"`, `NoteContent` uses `"content"`). Otherwise the new field will be treated as opaque preserved data and will not populate the typed field.
 
 **Limitation:** Sibling keys on each **`Extension`** object (alongside `provider`, `content`, `resourceRefs`) are still dropped. Non–`content.json` zip entries continue to be preserved by `WriteMap` via raw copy.
 
 **String encoding:** When persisting `content.json`, use **`xmind.WriteMap`** / **`xmind.CreateNewMap`** only. They marshal with `encoding/json` HTML escaping disabled so characters such as `&`, `<`, and `>` appear literally in JSON strings (matching XMind on-disk files). Do not use `json.Marshal` on `[]Sheet` for that payload; default marshaling can rewrite `json.Marshaler` output in ways XMind mishandles.
 
-**Notes:** `Notes` uses `*NoteContent` with `omitempty` so topics that only have `notes.plain` in the file do not gain an empty `notes.realHTML` on round-trip.
+**Notes:** `Notes` and `NoteContent` carry the same `extra` bag and custom codec as the other tree types, so unknown sibling keys (alongside `plain`/`realHTML` on the notes object, or alongside `content` inside a note body) survive a round-trip. `Notes` still uses `*NoteContent` with `omitempty` and only populates `Plain`/`RealHTML` when their keys are present, so topics that only have `notes.plain` in the file do not gain an empty `notes.realHTML` on round-trip.
 
 ---
 
@@ -358,9 +358,9 @@ Always preserve existing UUIDs — never regenerate them. Generate new UUIDs onl
 When writing a topic note, both fields must be populated. Writing only `plain` leaves the rich-text panel blank in XMind; writing raw text into `realHTML` directly renders unstyled. Use the `plainToRealHTML` helper in `mutate.go` to convert:
 
 ```go
-notes := &xmind.NoteContent{
-    Plain: xmind.NotesPlain{Content: plainText},
-    RealHTML: xmind.NotesRealHTML{Content: plainToRealHTML(plainText)},
+notes := &xmind.Notes{
+    Plain:    &xmind.NoteContent{Content: plainText},
+    RealHTML: &xmind.NoteContent{Content: plainToRealHTML(plainText)},
 }
 ```
 

--- a/internal/xmind/json_codec.go
+++ b/internal/xmind/json_codec.go
@@ -307,6 +307,65 @@ func (a *AttributedTitleItem) MarshalJSON() ([]byte, error) {
 	return encodeToRawMap((*alias)(a), a.extra)
 }
 
+// --- NoteContent ---
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (n *NoteContent) UnmarshalJSON(data []byte) error {
+	raw, err := unmarshalObjectMap(data)
+	if err != nil {
+		return err
+	}
+	ex := cloneJSONMap(raw)
+	deleteKeys(ex, "content")
+	if v, ok := raw["content"]; ok {
+		_ = json.Unmarshal(v, &n.Content)
+	}
+	n.extra = ex
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (n *NoteContent) MarshalJSON() ([]byte, error) {
+	type alias NoteContent
+	return encodeToRawMap((*alias)(n), n.extra)
+}
+
+// --- Notes ---
+
+// UnmarshalJSON implements json.Unmarshaler.
+// Plain and RealHTML are only populated when their keys are present, so a plain-only note
+// does not gain an empty realHTML on round-trip.
+func (n *Notes) UnmarshalJSON(data []byte) error {
+	raw, err := unmarshalObjectMap(data)
+	if err != nil {
+		return err
+	}
+	ex := cloneJSONMap(raw)
+	deleteKeys(ex, "plain", "realHTML")
+	if v, ok := raw["plain"]; ok && jsonValueIsPresent(v) {
+		var c NoteContent
+		if err := json.Unmarshal(v, &c); err != nil {
+			return err
+		}
+		n.Plain = &c
+	}
+	if v, ok := raw["realHTML"]; ok && jsonValueIsPresent(v) {
+		var c NoteContent
+		if err := json.Unmarshal(v, &c); err != nil {
+			return err
+		}
+		n.RealHTML = &c
+	}
+	n.extra = ex
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (n *Notes) MarshalJSON() ([]byte, error) {
+	type alias Notes
+	return encodeToRawMap((*alias)(n), n.extra)
+}
+
 // --- Children ---
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/internal/xmind/json_codec_test.go
+++ b/internal/xmind/json_codec_test.go
@@ -28,6 +28,106 @@ func TestNotesPlainOnlyNoRealHTML(t *testing.T) {
 	}
 }
 
+// TestNoteContentPreservesUnknownSiblingKeys covers issue #42 case 1: a key alongside
+// "content" inside a note body (e.g. notes.plain) must survive a round-trip.
+func TestNoteContentPreservesUnknownSiblingKeys(t *testing.T) {
+	const in = `{"content":"hi","foo":1}`
+	var nc NoteContent
+	if err := json.Unmarshal([]byte(in), &nc); err != nil {
+		t.Fatal(err)
+	}
+	if nc.Content != "hi" {
+		t.Fatalf("content: got %q want %q", nc.Content, "hi")
+	}
+	out, err := json.Marshal(&nc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["foo"]; !ok {
+		t.Fatalf("unknown sibling key foo dropped from NoteContent: %s", out)
+	}
+}
+
+// TestNotesPreservesUnknownSiblingKeys covers issue #42 case 2: a key alongside
+// "plain"/"realHTML" on the notes object must survive a round-trip.
+func TestNotesPreservesUnknownSiblingKeys(t *testing.T) {
+	const in = `{"plain":{"content":"hi"},"bar":2}`
+	var n Notes
+	if err := json.Unmarshal([]byte(in), &n); err != nil {
+		t.Fatal(err)
+	}
+	if n.Plain == nil || n.Plain.Content != "hi" {
+		t.Fatalf("plain: %+v", n.Plain)
+	}
+	out, err := json.Marshal(&n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["bar"]; !ok {
+		t.Fatalf("unknown sibling key bar dropped from Notes: %s", out)
+	}
+}
+
+// TestNotesUnknownKeysSurviveTopicRoundTrip exercises both issue #42 cases at once through a
+// full Topic unmarshal -> marshal, confirming the fix holds via the Topic decode path.
+func TestNotesUnknownKeysSurviveTopicRoundTrip(t *testing.T) {
+	const in = `{"id":"t1","class":"topic","title":"T",` +
+		`"notes":{"plain":{"content":"hi","foo":1},"bar":2}}`
+	var topic Topic
+	if err := json.Unmarshal([]byte(in), &topic); err != nil {
+		t.Fatal(err)
+	}
+	out, err := json.Marshal(&topic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top struct {
+		Notes struct {
+			Plain map[string]json.RawMessage `json:"plain"`
+			Bar   json.RawMessage            `json:"bar"`
+		} `json:"notes"`
+	}
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := top.Notes.Plain["foo"]; !ok {
+		t.Errorf("note-body sibling key foo dropped through Topic round-trip: %s", out)
+	}
+	if len(top.Notes.Bar) == 0 {
+		t.Errorf("notes-object sibling key bar dropped through Topic round-trip: %s", out)
+	}
+}
+
+// TestNotesAndNoteContentUnmarshalErrors covers the error branches of the note codecs:
+// a non-object body, and a malformed plain/realHTML value that fails to decode as a note.
+func TestNotesAndNoteContentUnmarshalErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		dst  json.Unmarshaler
+	}{
+		{"NoteContent non-object", `[1,2]`, new(NoteContent)},
+		{"Notes non-object", `[1,2]`, new(Notes)},
+		{"Notes malformed plain", `{"plain":[1]}`, new(Notes)},
+		{"Notes malformed realHTML", `{"realHTML":[1]}`, new(Notes)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := json.Unmarshal([]byte(tc.in), tc.dst); err == nil {
+				t.Fatalf("expected error unmarshalling %q, got nil", tc.in)
+			}
+		})
+	}
+}
+
 func TestTopicTitleMarshalUsesRawAmpersandInJSON(t *testing.T) {
 	topic := Topic{
 		ID:    "t1",
@@ -191,6 +291,42 @@ func TestSheetMarshalPreservesRootTopicUnknownKeys(t *testing.T) {
 	}
 	if _, ok := top.RootTopic["customRootKey"]; !ok {
 		t.Fatalf("missing customRootKey on rootTopic after marshal: %s", out)
+	}
+}
+
+// TestWriteMapZipRoundTripPreservesNotesExtra checks that a ReadMap -> WriteMap -> ReadMap cycle
+// keeps preserved (unknown) keys at both the Notes level and the NoteContent level. Notes are
+// attached to the root topic so the test does not depend on the fixture having note-bearing topics.
+func TestWriteMapZipRoundTripPreservesNotesExtra(t *testing.T) {
+	sheets, dst := readKitchenSinkCopy(t, "preserve-notes.xmind")
+	const notesKey = "_xmindMcpNotesPreserve"
+	const contentKey = "_xmindMcpNoteContentPreserve"
+	sheets[0].RootTopic.Notes = &Notes{
+		Plain: &NoteContent{
+			Content: "n",
+			extra:   map[string]json.RawMessage{contentKey: json.RawMessage(`{"at":"content"}`)},
+		},
+		extra: map[string]json.RawMessage{notesKey: json.RawMessage(`{"at":"notes"}`)},
+	}
+	if err := WriteMap(dst, sheets); err != nil {
+		t.Fatal(err)
+	}
+	sheets2, err := ReadMap(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	notes := sheets2[0].RootTopic.Notes
+	if notes == nil {
+		t.Fatal("notes lost after round-trip")
+	}
+	if _, ok := notes.extra[notesKey]; !ok {
+		t.Errorf("Notes-level extra key %q dropped after zip round-trip", notesKey)
+	}
+	if notes.Plain == nil {
+		t.Fatal("notes.plain lost after round-trip")
+	}
+	if _, ok := notes.Plain.extra[contentKey]; !ok {
+		t.Errorf("NoteContent-level extra key %q dropped after zip round-trip", contentKey)
 	}
 }
 

--- a/internal/xmind/types.go
+++ b/internal/xmind/types.go
@@ -98,14 +98,18 @@ type TopicImage struct {
 
 // Notes holds plain and HTML note content.
 // Either or both of Plain and RealHTML may be set; omitted keys are not reintroduced on marshal.
+// Unknown sibling keys are preserved via extra, like other workbook-tree objects.
 type Notes struct {
 	Plain    *NoteContent `json:"plain,omitempty"`
 	RealHTML *NoteContent `json:"realHTML,omitempty"`
+	extra    map[string]json.RawMessage
 }
 
 // NoteContent wraps note body.
+// Unknown sibling keys (alongside content) are preserved via extra.
 type NoteContent struct {
 	Content string `json:"content"`
+	extra   map[string]json.RawMessage
 }
 
 // Extension is task/audio/math metadata on a topic.


### PR DESCRIPTION
`Notes` and `NoteContent` were the only workbook-tree objects without an `extra` bag and custom codec, so any unknown sibling key XMind stored alongside `plain`/`realHTML` or alongside `content` was silently dropped on a read -> write cycle, breaking the fidelity guarantee held by every other tree type.

Changes:
- Add unexported `extra` bag to `Notes` and `NoteContent` in `types.go`
- Add `MarshalJSON`/`UnmarshalJSON` for both in `json_codec.go`, following the `Boundary`/`Marker` pattern; `Notes` gates `Plain`/ `RealHTML` behind `jsonValueIsPresent` so plain-only notes still do not gain an empty `realHTML` on round-trip
- Add codec and zip round-trip tests covering both sibling-key cases
- Update `AGENTS.md`: document the new preservation, add the types to the allowlist enumeration, and fix a stale `NotesPlain`/`NotesRealHTML` snippet and `json:"-"` note

Closes #42