### PR TITLE
Return tool error for DuplicateTopic dangling summary ref

### DIFF
--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -57,6 +57,16 @@ func countTopics(t *xmind.Topic) int {
 	return n
 }
 
+// cloneDanglingSummaryRefError signals that a cloned summary descriptor references a topicId
+// absent from the cloned subtree. The source map opened fine, so this is caller-fixable bad
+// input (duplicate a different topic, or point at a different file) — handlers surface it as a
+// tool error, not a protocol error.
+type cloneDanglingSummaryRefError struct{ topicID string }
+
+func (e *cloneDanglingSummaryRefError) Error() string {
+	return fmt.Sprintf("clone topic: summary topicId %q not found in cloned subtree", e.topicID)
+}
+
 // deepCloneTopic returns a deep copy of the topic subtree with JSON round-trip (preserves codec `extra`
 // data), then assigns fresh UUIDs to every topic and to summary/boundary descriptors within the clone.
 func deepCloneTopic(root *xmind.Topic) (xmind.Topic, error) {
@@ -97,7 +107,7 @@ func remapClonedTopicIDs(root *xmind.Topic) error {
 			if oldTopicRef != "" {
 				newRef, ok := idMap[oldTopicRef]
 				if !ok {
-					remapErr = fmt.Errorf("clone topic: summary topicId %q not found in cloned subtree", oldTopicRef)
+					remapErr = &cloneDanglingSummaryRefError{topicID: oldTopicRef}
 					return false
 				}
 				s.TopicID = newRef

--- a/internal/server/handler/handler_test.go
+++ b/internal/server/handler/handler_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -67,6 +69,36 @@ func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
 	assertDeepCloneRootAndAttached(t, root, &clone, summaryTopicID)
 	assertDeepCloneBoundaries(t, &clone)
 	assertDeepCloneSummaryDescriptors(t, &clone)
+}
+
+// danglingSummaryFixtureTopic builds a topic whose summary descriptor references a topicId that
+// exists nowhere in its subtree (no matching Children.Summary entry).
+func danglingSummaryFixtureTopic() *xmind.Topic {
+	return &xmind.Topic{
+		ID: "root-old",
+		Summaries: []xmind.Summary{
+			{ID: "sum-old", Range: "(0,0)", TopicID: "ghost-id"},
+		},
+		Children: &xmind.Children{
+			Attached: []xmind.Topic{{ID: "a-old", Title: "A"}},
+		},
+	}
+}
+
+// TestDeepCloneTopicDanglingSummaryRef pins the dangling-reference failure to the typed
+// cloneDanglingSummaryRefError so callers can classify it as a tool error (issue #46).
+func TestDeepCloneTopicDanglingSummaryRef(t *testing.T) {
+	_, err := deepCloneTopic(danglingSummaryFixtureTopic())
+	if err == nil {
+		t.Fatal("expected an error for a dangling summary reference, got nil")
+	}
+	var dangErr *cloneDanglingSummaryRefError
+	if !errors.As(err, &dangErr) {
+		t.Fatalf("expected *cloneDanglingSummaryRefError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "not found in cloned subtree") {
+		t.Fatalf("unexpected message: %q", err.Error())
+	}
 }
 
 func TestAncestryPathHelper(t *testing.T) {

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"math"
@@ -152,12 +153,12 @@ func parseSummaryRange(r string) (from, to int, ok bool) {
 		return 0, 0, false
 	}
 	inner := strings.TrimSpace(r[1 : len(r)-1])
-	comma := strings.IndexByte(inner, ',')
-	if comma < 0 {
+	left, right, found := strings.Cut(inner, ",")
+	if !found {
 		return 0, 0, false
 	}
-	f, err1 := strconv.Atoi(strings.TrimSpace(inner[:comma]))
-	t, err2 := strconv.Atoi(strings.TrimSpace(inner[comma+1:]))
+	f, err1 := strconv.Atoi(strings.TrimSpace(left))
+	t, err2 := strconv.Atoi(strings.TrimSpace(right))
 	if err1 != nil || err2 != nil {
 		return 0, 0, false
 	}
@@ -485,6 +486,16 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 	})
 }
 
+// duplicateCloneFailure maps a deepCloneTopic error to the right MCP failure shape: a tool error
+// for a caller-fixable dangling summary reference (the source map opened fine), a protocol error
+// otherwise (nil root / JSON round-trip failures are genuine internal faults).
+func duplicateCloneFailure(err error) (*mcp.CallToolResult, error) {
+	if dangErr, ok := errors.AsType[*cloneDanglingSummaryRefError](err); ok {
+		return mcp.NewToolResultError(dangErr.Error()), nil
+	}
+	return nil, fmt.Errorf("duplicate topic: %w", err)
+}
+
 // DuplicateTopic deep-clones a topic subtree and attaches it as an attached child of target_parent_id.
 func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	_ = ctx
@@ -517,7 +528,7 @@ func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolReque
 
 	clone, err := deepCloneTopic(source)
 	if err != nil {
-		return nil, fmt.Errorf("duplicate topic: %w", err)
+		return duplicateCloneFailure(err)
 	}
 	newRootID := clone.ID
 	n := countTopics(&clone)

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -2298,6 +2299,109 @@ func TestDuplicateTopicErrors(t *testing.T) {
 	})
 	if !res.IsError || !strings.Contains(textContent(t, res), "out of range") {
 		t.Fatalf("expected position out of range, got %q", textContent(t, res))
+	}
+}
+
+// TestDuplicateTopicDanglingSummaryRefReturnsToolError reproduces issue #46: duplicating a
+// topic whose summary descriptor references a topicId absent from its subtree must surface as
+// a tool-level error (nil Go error, IsError result), not a protocol error. The handler is
+// invoked directly because callTool would t.Fatalf on the pre-fix protocol error.
+func TestDuplicateTopicDanglingSummaryRefReturnsToolError(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dangling.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid := sheets[0].ID
+	rootID := sheets[0].RootTopic.ID
+
+	// Attach a child to duplicate that carries a summary descriptor whose topicId points at
+	// an id present nowhere in its subtree, then persist the malformed-but-openable map.
+	mid := uuid.New().String()
+	sheets[0].RootTopic.Children = &xmind.Children{
+		Attached: []xmind.Topic{
+			{
+				ID:    mid,
+				Title: "Mid",
+				Summaries: []xmind.Summary{
+					{ID: uuid.New().String(), Range: "(0,0)", TopicID: "ghost-id"},
+				},
+				Children: &xmind.Children{
+					Attached: []xmind.Topic{{ID: uuid.New().String(), Title: "Leaf"}},
+				},
+			},
+		},
+	}
+	if err := xmind.WriteMap(path, sheets); err != nil {
+		t.Fatal(err)
+	}
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": mid, "target_parent_id": rootID,
+	}}}
+	res, err := h.DuplicateTopic(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected a tool error (nil Go error), got protocol error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected tool-level error result, got %+v", res)
+	}
+	if msg := textContent(t, res); !strings.Contains(msg, "not found in cloned subtree") {
+		t.Fatalf("unexpected error message: %q", msg)
+	}
+}
+
+// TestDuplicateCloneFailure covers both classification branches: a dangling summary reference is
+// caller-fixable (tool error, nil Go error), while any other clone failure is a genuine internal
+// fault (protocol error). The protocol-error path is unreachable via DuplicateTopic with normal
+// input, so it is exercised here directly.
+func TestDuplicateCloneFailure(t *testing.T) {
+	res, err := duplicateCloneFailure(&cloneDanglingSummaryRefError{topicID: "ghost-id"})
+	if err != nil {
+		t.Fatalf("dangling ref: expected nil Go error, got %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("dangling ref: expected tool error result, got %+v", res)
+	}
+	if msg := textContent(t, res); !strings.Contains(msg, "ghost-id") {
+		t.Fatalf("dangling ref: unexpected message %q", msg)
+	}
+
+	res, err = duplicateCloneFailure(fmt.Errorf("boom"))
+	if res != nil {
+		t.Fatalf("internal fault: expected nil result, got %+v", res)
+	}
+	if err == nil || !strings.Contains(err.Error(), "duplicate topic:") {
+		t.Fatalf("internal fault: expected wrapped protocol error, got %v", err)
+	}
+}
+
+func TestParseSummaryRange(t *testing.T) {
+	cases := []struct {
+		in       string
+		from, to int
+		ok       bool
+	}{
+		{"(0,2)", 0, 2, true},
+		{" ( 1 , 3 ) ", 1, 3, true},
+		{"(2,2)", 2, 2, true},
+		{"", 0, 0, false},       // too short, fails the paren/length guard
+		{"[0,2]", 0, 0, false},  // not paren-wrapped
+		{"(0123)", 0, 0, false}, // paren-wrapped but no comma
+		{"(a,2)", 0, 0, false},  // non-numeric bound
+		{"(2,0)", 0, 0, false},  // from greater than to
+		{"(-1,2)", 0, 0, false}, // negative bound
+	}
+	for _, c := range cases {
+		from, to, ok := parseSummaryRange(c.in)
+		if ok != c.ok || from != c.from || to != c.to {
+			t.Errorf("parseSummaryRange(%q) = (%d,%d,%v), want (%d,%d,%v)",
+				c.in, from, to, ok, c.from, c.to, c.ok)
+		}
 	}
 }
 


### PR DESCRIPTION
When a duplicated topic's summary descriptor references a topicId absent from its subtree, `DuplicateTopic` returned the error as a protocol error, which looks like a server crash to the model. The source map opened fine, so this is caller-fixable bad input and must surface as a tool error per the project error-handling convention.

Fixes:
- Add typed `cloneDanglingSummaryRefError` from `remapClonedTopicIDs` and map it to `mcp.NewToolResultError` via `duplicateCloneFailure`; internal faults stay protocol errors
- Add regression and unit tests written before the fix

Changes:
- Simplify `parseSummaryRange` with `strings.Cut` (unrelated modernization)

Closes #46