### PR TITLE
Reject self-loop relationships in AddRelationship

### DIFF
--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -1215,6 +1215,10 @@ func parseBulkTopicsArray(args map[string]any) ([]any, *mcp.CallToolResult) {
 }
 
 func requireRelationshipEndpoints(root *xmind.Topic, fromID, toID string) *mcp.CallToolResult {
+	if fromID == toID {
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"relationship endpoints must differ: from_id and to_id are the same topic (%s)", fromID))
+	}
 	if findTopicByID(root, fromID) == nil {
 		return mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", fromID))
 	}

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -1513,6 +1513,34 @@ func TestAddRelationshipInvalidTopic(t *testing.T) {
 	}
 }
 
+func TestAddRelationshipSelfLoop(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rel_selfloop.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, _ := xmind.ReadMap(path)
+	sid := sheets[0].ID
+	rid := sheets[0].RootTopic.ID
+	aID := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rid, "title": "A",
+	})).ID
+
+	res := callTool(t, h.AddRelationship, map[string]any{
+		"path": path, "sheet_id": sid, "from_id": aID, "to_id": aID,
+	})
+	if !res.IsError {
+		t.Fatal("expected error for self-loop relationship (from_id == to_id)")
+	}
+	if msg := textContent(t, res); !strings.Contains(msg, "must differ") {
+		t.Fatalf("unexpected error message: %q", msg)
+	}
+
+	sheets, _ = xmind.ReadMap(path)
+	if n := len(sheets[0].Relationships); n != 0 {
+		t.Fatalf("expected 0 relationships after self-loop rejection, got %d: %+v", n, sheets[0].Relationships)
+	}
+}
+
 func TestAddRelationshipLabelWrongType(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -229,7 +229,7 @@ var toolAddFloatingTopic = mcp.NewTool(
 
 var toolAddRelationship = mcp.NewTool(
 	"xmind_add_relationship",
-	mcp.WithDescription("Add a relationship (connector) between two topics. Stored at sheet level, not on topics."),
+	mcp.WithDescription("Add a relationship (connector) between two topics. Stored at sheet level, not on topics. from_id and to_id must be different topics."),
 	mcp.WithString("path", mcp.Required(), mcp.Description("Absolute or relative path to the .xmind file")),
 	mcp.WithString("sheet_id", mcp.Required(), mcp.Description("Target sheet")),
 	mcp.WithString("from_id", mcp.Required(), mcp.Description("Source topic ID (end1Id)")),


### PR DESCRIPTION
`requireRelationshipEndpoints` verified that `from_id` and `to_id` resolved to existing topics but never checked that they differ. A `from_id == to_id` request was accepted and a self-referential relationship was persisted to `Sheet.Relationships`. XMind does not render a topic-to-itself connector usefully, so this wrote a confusing no-op into the file.

Changes:
- Add an equality guard at the top of `requireRelationshipEndpoints` that returns a tool error when `from_id == to_id`, before the endpoint-existence checks; no relationship is appended and the file is left untouched
- Note the constraint in the `xmind_add_relationship` tool description
- Add `TestAddRelationshipSelfLoop` asserting the tool error and that no relationship is written

Closes #47