### PR TITLE
Preserve original file on failed Windows write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ internal/
     json_codec.go         — custom JSON: preserve unknown keys, notes shape
     reader.go             — open zip, parse content.json → []Sheet
     writer.go             — serialize []Sheet → content.json, write back to zip
-    atomic_replace.go     — replaceTempFile: cross-platform atomic rename helper
+    atomic_replace.go     — replaceTempFile/replaceViaBackup: atomic replace (backup-restore on Windows)
     defaults.go           — DefaultTheme and DefaultSheetExtensions for new maps
     default_theme.json    — embedded default theme blob (sourced from kitchen-sink fixture)
     stub_content.xml      — embedded legacy content.xml written into every new zip
@@ -102,6 +102,8 @@ Every mutating tool call follows this exact pattern — do not deviate from it:
 ```
 
 **Atomicity is required.** Always write to a temp file first and rename/swap on success. If a write fails mid-way, the original file must be left untouched. There is no session state and no temp files left behind on failure.
+
+The temp-then-swap happens in `replaceTempFile` (`internal/xmind/atomic_replace.go`). On Unix, `os.Rename` atomically replaces the destination. On Windows, `os.Rename` cannot overwrite an existing file, so `replaceViaBackup` moves the original aside to a uniquely named backup first, renames the temp into place, then removes the backup — restoring the backup if the rename fails. This keeps the original recoverable on Windows; never reintroduce a plain remove-then-rename there, which can destroy the original if the rename fails.
 
 ### `content.json` fidelity (unknown keys)
 

--- a/internal/xmind/atomic_replace.go
+++ b/internal/xmind/atomic_replace.go
@@ -6,17 +6,61 @@ import (
 	"runtime"
 )
 
+// osRename is a seam over os.Rename so tests can force the rename failures that
+// drive replaceViaBackup's restore path. Production always uses os.Rename.
+var osRename = os.Rename
+
 // replaceTempFile moves tmpPath to dst as the final step of an atomic write.
-// On Unix, os.Rename replaces an existing dst. On Windows, Rename fails if dst
-// exists, so we remove dst first (not atomic with rename; acceptable for local .xmind I/O).
+// On Unix, os.Rename atomically replaces an existing dst. On Windows, Rename
+// fails if dst exists, so the original must be moved aside first; replaceViaBackup
+// does so via a backup so a mid-write failure still leaves the original recoverable.
 func replaceTempFile(tmpPath, dst string) error {
 	if runtime.GOOS == "windows" {
-		if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove existing file: %w", err)
-		}
+		return replaceViaBackup(tmpPath, dst)
 	}
-	if err := os.Rename(tmpPath, dst); err != nil {
+	if err := osRename(tmpPath, dst); err != nil {
 		return fmt.Errorf("rename temp to target: %w", err)
+	}
+	return nil
+}
+
+// replaceViaBackup moves tmpPath to dst on platforms where os.Rename cannot
+// overwrite an existing file (Windows). The original dst is moved aside to a
+// backup before the temp file is renamed into place, so a failure at any step
+// leaves the original intact and recoverable; on a failed move-into-place the
+// backup is restored. It is OS-agnostic so it can be tested directly on any
+// platform.
+func replaceViaBackup(tmpPath, dst string) error {
+	// The backup name is derived from tmpPath (which os.CreateTemp already made
+	// unique), so a collision is effectively impossible; and if a ".bak" sibling
+	// somehow existed, the Windows os.Rename below would fail safely, leaving the
+	// original in place.
+	backup := tmpPath + ".bak"
+
+	haveBackup := false
+	if _, err := os.Stat(dst); err == nil {
+		if err := osRename(dst, backup); err != nil {
+			return fmt.Errorf("back up existing file: %w", err)
+		}
+		haveBackup = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat target: %w", err)
+	}
+
+	if err := osRename(tmpPath, dst); err != nil {
+		if haveBackup {
+			if rerr := osRename(backup, dst); rerr != nil {
+				return fmt.Errorf("rename temp to target: %w; original preserved at %q (restore failed: %v)", err, backup, rerr)
+			}
+			return fmt.Errorf("rename temp to target: %w (original restored)", err)
+		}
+		return fmt.Errorf("rename temp to target: %w", err)
+	}
+
+	// The write succeeded; removing the backup is best effort and must not turn
+	// a successful write into a reported failure.
+	if haveBackup {
+		_ = os.Remove(backup)
 	}
 	return nil
 }

--- a/internal/xmind/atomic_replace_test.go
+++ b/internal/xmind/atomic_replace_test.go
@@ -1,0 +1,142 @@
+package xmind
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests exercise replaceViaBackup directly. It is the replace strategy used
+// on Windows (where os.Rename cannot overwrite an existing file), but it relies
+// only on os.Stat/os.Rename/os.Remove, whose semantics for this pattern are the
+// same on Linux, so the logic is fully covered on the (Linux) CI without build
+// tags or test-only globals.
+
+// mustWriteFile writes content to path, failing the test on error.
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// readFileString reads path and returns its content as a string.
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// TestReplaceViaBackupOverwriteSuccess verifies that an existing dst is replaced
+// with the temp file's contents, leaving neither the temp file nor a backup.
+func TestReplaceViaBackupOverwriteSuccess(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "target")
+	tmpPath := filepath.Join(dir, ".xmind-tmp-001")
+	mustWriteFile(t, dst, "ORIGINAL")
+	mustWriteFile(t, tmpPath, "REPLACEMENT")
+
+	if err := replaceViaBackup(tmpPath, dst); err != nil {
+		t.Fatalf("replaceViaBackup: unexpected error: %v", err)
+	}
+
+	if got := readFileString(t, dst); got != "REPLACEMENT" {
+		t.Fatalf("dst content = %q, want %q", got, "REPLACEMENT")
+	}
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file should be consumed, stat err = %v", err)
+	}
+	if _, err := os.Stat(tmpPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("backup should not remain, stat err = %v", err)
+	}
+}
+
+// TestReplaceViaBackupRestoreOnFailure is the regression test for issue #41: when
+// the move-into-place step fails, the original dst must be left intact and
+// recoverable, never destroyed. Failure is forced naturally by passing a tmpPath
+// that does not exist, so the rename of tmp -> dst fails.
+func TestReplaceViaBackupRestoreOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "target")
+	tmpPath := filepath.Join(dir, ".xmind-tmp-missing") // intentionally never created
+	mustWriteFile(t, dst, "ORIGINAL")
+
+	err := replaceViaBackup(tmpPath, dst)
+	if err == nil {
+		t.Fatal("expected replaceViaBackup to fail when the temp file is missing")
+	}
+
+	if got := readFileString(t, dst); got != "ORIGINAL" {
+		t.Fatalf("original must survive a failed replace: dst content = %q, want %q", got, "ORIGINAL")
+	}
+	if _, err := os.Stat(tmpPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("backup should not remain after a successful restore, stat err = %v", err)
+	}
+}
+
+// TestReplaceViaBackupNewFile verifies the no-original case (e.g. CreateNewMap):
+// when dst does not yet exist, the temp file is moved into place with no backup.
+func TestReplaceViaBackupNewFile(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "target") // intentionally absent
+	tmpPath := filepath.Join(dir, ".xmind-tmp-002")
+	mustWriteFile(t, tmpPath, "CONTENT")
+
+	if err := replaceViaBackup(tmpPath, dst); err != nil {
+		t.Fatalf("replaceViaBackup: unexpected error: %v", err)
+	}
+
+	if got := readFileString(t, dst); got != "CONTENT" {
+		t.Fatalf("dst content = %q, want %q", got, "CONTENT")
+	}
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file should be consumed, stat err = %v", err)
+	}
+	if _, err := os.Stat(tmpPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("backup should not exist for a new file, stat err = %v", err)
+	}
+}
+
+// TestReplaceViaBackupReportsBackupWhenRestoreFails covers the double-fault path:
+// the temp file cannot be moved into place AND the backup cannot be restored. The
+// original must survive on disk under the backup name, and the returned error must
+// name that backup so the user can recover manually. A failing rename is injected
+// via the osRename seam (the only portable way to force the restore to fail).
+func TestReplaceViaBackupReportsBackupWhenRestoreFails(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "target")
+	tmpPath := filepath.Join(dir, ".xmind-tmp-003")
+	mustWriteFile(t, dst, "ORIGINAL")
+	mustWriteFile(t, tmpPath, "REPLACEMENT")
+
+	// Fail every rename whose destination is dst: the move-into-place (tmp -> dst)
+	// fails, and so does the restore (backup -> dst). The initial dst -> backup
+	// move (destination != dst) still runs for real, so the backup holds the
+	// original on disk.
+	orig := osRename
+	t.Cleanup(func() { osRename = orig })
+	osRename = func(oldpath, newpath string) error {
+		if newpath == dst {
+			return errors.New("injected rename failure")
+		}
+		return orig(oldpath, newpath)
+	}
+
+	err := replaceViaBackup(tmpPath, dst)
+	if err == nil {
+		t.Fatal("expected replaceViaBackup to fail when the restore also fails")
+	}
+
+	backup := tmpPath + ".bak"
+	if !strings.Contains(err.Error(), backup) {
+		t.Fatalf("error must name the backup path %q for recovery, got: %v", backup, err)
+	}
+	if got := readFileString(t, backup); got != "ORIGINAL" {
+		t.Fatalf("original must survive at the backup: content = %q, want %q", got, "ORIGINAL")
+	}
+}


### PR DESCRIPTION
On Windows, os.Rename cannot overwrite an existing file, so `replaceTempFile` removed the destination before renaming the temp into place. If that rename then failed (destination locked, antivirus, transient I/O) or the process died between the two calls, the original .xmind was gone -- and `WriteMap`'s deferred cleanup deleted the temp too, losing both copies. This broke the atomicity guarantee in AGENTS.md.

This commit replaces the Windows remove-then-rename operation with `replaceViaBackup` which moves the original aside to a uniquely named backup, renames the temp into place, then removes the backup; on a failed rename it restores the backup, and on a double fault it reports the backup path so the original stays recoverable. The Unix path is left as the single atomic `os.Rename`

Changes:
- Add `internal/xmind/atomic_replace_test.go` (written test-first): overwrite, restore-on-failure regression, new-file, and the double-fault case exercised via an `osRename` test seam
- Document the Windows backup-rename mechanism in `AGENTS.md` and update the project-structure note for `atomic_replace.go`

Closes #41