### PR TITLE
Migrate handlers to shared argument-extraction helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,12 +178,31 @@ if err != nil {
 }
 ```
 
-For additional non-path arguments (string, int, bool), extract them directly from `args` after the path helpers:
+For additional non-path arguments, use the shared extraction helpers rather than inlining `args[...]` lookups and type assertions. Each returns a `*mcp.CallToolResult` tool error you forward with `if … != nil { return …, nil }`:
+
+| Helper | Location | Semantics |
+|---|---|---|
+| `requireString(args, key)` | `mutate.go` | Required string; rejects missing, non-string, and empty. |
+| `stringArgAllowEmpty(args, key)` | `utils.go` | Required string; rejects missing and non-string, but permits empty. |
+| `requireNonNegativeInt(args, key)` | `mutate.go` | Required whole number ≥ 0 (accepts JSON `float64` or `int`). |
+| `optionalString(args, key)` | `handler.go` | Optional string → `(val, present, toolErr)`. `present=false` when absent/null; errors only on a non-string value; empty string is returned as-is for the caller to interpret (default vs. reject). |
 
 ```go
-title, _ := args["title"].(string)
-if title == "" {
-    return mcp.NewToolResultError("missing required argument: title"), nil
+title, terr := requireString(args, "title")
+if terr != nil {
+    return terr, nil
+}
+```
+
+For an optional argument with a default, let the caller decide what empty means:
+
+```go
+sheetTitle, present, terr := optionalString(args, "sheet_title")
+if terr != nil {
+    return terr, nil
+}
+if !present || sheetTitle == "" {
+    sheetTitle = "Sheet 1"
 }
 ```
 

--- a/internal/server/handler/find.go
+++ b/internal/server/handler/find.go
@@ -135,33 +135,18 @@ func parseBoolOptional(args map[string]any, key string) (bool, *mcp.CallToolResu
 	return false, nil
 }
 
-// requireSheetIDFromArgs reads and validates args["sheet_id"] like GetSubtree/FindTopic.
-func requireSheetIDFromArgs(args map[string]any) (sheetID string, toolErr *mcp.CallToolResult) {
-	rawSheet, ok := args["sheet_id"]
-	if !ok {
-		return "", mcp.NewToolResultError("missing required argument: sheet_id")
-	}
-	sid, ok := rawSheet.(string)
-	if !ok || sid == "" {
-		return "", mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string")
-	}
-	return sid, nil
-}
-
 // getSubtreeRootFromArgs resolves the subtree root from optional topic_id (empty string = sheet root).
 func getSubtreeRootFromArgs(sh *xmind.Sheet, args map[string]any) (root *xmind.Topic, toolErr *mcp.CallToolResult) {
-	if v, has := args["topic_id"]; has && v != nil {
-		rawTopic, ok := v.(string)
-		if !ok {
-			return nil, mcp.NewToolResultError("invalid argument topic_id: expected a string")
+	id, present, terr := optionalString(args, "topic_id")
+	if terr != nil {
+		return nil, terr
+	}
+	if present && id != "" {
+		t := findTopicByID(&sh.RootTopic, id)
+		if t == nil {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", id))
 		}
-		if rawTopic != "" {
-			t := findTopicByID(&sh.RootTopic, rawTopic)
-			if t == nil {
-				return nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", rawTopic))
-			}
-			return t, nil
-		}
+		return t, nil
 	}
 	return &sh.RootTopic, nil
 }
@@ -210,7 +195,7 @@ func (h *XMindHandler) GetSubtree(ctx context.Context, req mcp.CallToolRequest) 
 		return toolErr, nil
 	}
 
-	sheetID, serr := requireSheetIDFromArgs(args)
+	sheetID, serr := requireString(args, "sheet_id")
 	if serr != nil {
 		return serr, nil
 	}
@@ -259,9 +244,12 @@ type searchTopicItem struct {
 
 // searchSheetsScopeFromArgs returns sheets to search and whether to attach sheet metadata per match.
 func searchSheetsScopeFromArgs(sheets []xmind.Sheet, args map[string]any) (toSearch []xmind.Sheet, includeSheetMetadata bool, toolErr *mcp.CallToolResult) {
-	if raw, has := args["sheet_id"]; has && raw != nil {
-		sheetID, ok := raw.(string)
-		if !ok || sheetID == "" {
+	sheetID, present, terr := optionalString(args, "sheet_id")
+	if terr != nil {
+		return nil, false, terr
+	}
+	if present {
+		if sheetID == "" {
 			return nil, false, mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string")
 		}
 		sh := findSheetByID(sheets, sheetID)
@@ -309,16 +297,9 @@ func (h *XMindHandler) SearchTopics(ctx context.Context, req mcp.CallToolRequest
 		return toolErr, nil
 	}
 
-	rawQuery, ok := args["query"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: query"), nil
-	}
-	query, ok := rawQuery.(string)
-	if !ok {
-		return mcp.NewToolResultError("invalid argument query: expected a string"), nil
-	}
-	if query == "" {
-		return mcp.NewToolResultError("invalid argument query: expected a non-empty string"), nil
+	query, terr := requireString(args, "query")
+	if terr != nil {
+		return terr, nil
 	}
 
 	sheets, toolErr2, err := statAndReadMap(absPath)
@@ -410,11 +391,11 @@ func childTitlesInWalkOrder(t *xmind.Topic) []string {
 
 // findTopicSearchRoot returns the topic at which to start the FindTopic walk (sheet root or parent_id subtree).
 func findTopicSearchRoot(sh *xmind.Sheet, args map[string]any) (searchRoot *xmind.Topic, toolErr *mcp.CallToolResult) {
-	if v, has := args["parent_id"]; has && v != nil {
-		pid, ok := v.(string)
-		if !ok {
-			return nil, mcp.NewToolResultError("invalid argument parent_id: expected a string")
-		}
+	pid, present, terr := optionalString(args, "parent_id")
+	if terr != nil {
+		return nil, terr
+	}
+	if present {
 		if pid == "" {
 			return nil, mcp.NewToolResultError("invalid argument parent_id: expected a non-empty string")
 		}
@@ -425,21 +406,6 @@ func findTopicSearchRoot(sh *xmind.Sheet, args map[string]any) (searchRoot *xmin
 		return topic, nil
 	}
 	return &sh.RootTopic, nil
-}
-
-func requireFindTopicTitleArgs(args map[string]any) (wantTitle string, toolErr *mcp.CallToolResult) {
-	rawTitle, ok := args["title"]
-	if !ok {
-		return "", mcp.NewToolResultError("missing required argument: title")
-	}
-	title, ok := rawTitle.(string)
-	if !ok {
-		return "", mcp.NewToolResultError("invalid argument title: expected a string")
-	}
-	if title == "" {
-		return "", mcp.NewToolResultError("invalid argument title: expected a non-empty string")
-	}
-	return title, nil
 }
 
 func findFirstTopicByExactTitle(searchRoot *xmind.Topic, wantTitle string) (found *xmind.Topic, foundParent *xmind.Topic) {
@@ -498,12 +464,12 @@ func (h *XMindHandler) FindTopic(ctx context.Context, req mcp.CallToolRequest) (
 		return toolErr, nil
 	}
 
-	sheetID, serr := requireSheetIDFromArgs(args)
+	sheetID, serr := requireString(args, "sheet_id")
 	if serr != nil {
 		return serr, nil
 	}
 
-	wantTitle, terr := requireFindTopicTitleArgs(args)
+	wantTitle, terr := requireString(args, "title")
 	if terr != nil {
 		return terr, nil
 	}

--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -310,6 +310,21 @@ func absPathFromArgs(args map[string]any) (abs string, toolErr *mcp.CallToolResu
 	return absPath, nil
 }
 
+// optionalString reads args[key] when present. Returns present=false when the key
+// is absent or null. It errors only on a non-string value; an empty string is
+// returned as-is (present=true) for the caller to interpret (default vs. reject).
+func optionalString(args map[string]any, key string) (val string, present bool, toolErr *mcp.CallToolResult) {
+	v, has := args[key]
+	if !has || v == nil {
+		return "", false, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false, mcp.NewToolResultError("invalid argument " + key + ": expected a string")
+	}
+	return s, true, nil
+}
+
 // statAndReadMap checks that absPath exists, reads the workbook, and maps I/O and parse failures
 // to tool errors vs protocol errors per 00-OVERVIEW.
 func statAndReadMap(absPath string) (sheets []xmind.Sheet, toolErr *mcp.CallToolResult, err error) {

--- a/internal/server/handler/sheets.go
+++ b/internal/server/handler/sheets.go
@@ -244,18 +244,17 @@ func (h *XMindHandler) CreateMap(ctx context.Context, req mcp.CallToolRequest) (
 		return toolErr, nil
 	}
 
-	rawRoot, ok := args["root_title"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: root_title"), nil
-	}
-	rootTitle, ok := rawRoot.(string)
-	if !ok || rootTitle == "" {
-		return mcp.NewToolResultError("invalid argument root_title: expected a non-empty string"), nil
+	rootTitle, terr := requireString(args, "root_title")
+	if terr != nil {
+		return terr, nil
 	}
 
-	sheetTitle := "Sheet 1"
-	if v, ok := args["sheet_title"].(string); ok && v != "" {
-		sheetTitle = v
+	sheetTitle, present, terr := optionalString(args, "sheet_title")
+	if terr != nil {
+		return terr, nil
+	}
+	if !present || sheetTitle == "" {
+		sheetTitle = "Sheet 1"
 	}
 
 	if _, err := os.Stat(absPath); err == nil {
@@ -318,13 +317,9 @@ func (h *XMindHandler) DeleteSheet(ctx context.Context, req mcp.CallToolRequest)
 		return toolErr, nil
 	}
 
-	rawID, ok := args["sheet_id"]
-	if !ok {
-		return mcp.NewToolResultError("missing required argument: sheet_id"), nil
-	}
-	sheetID, ok := rawID.(string)
-	if !ok || sheetID == "" {
-		return mcp.NewToolResultError("invalid argument sheet_id: expected a non-empty string"), nil
+	sheetID, terr := requireString(args, "sheet_id")
+	if terr != nil {
+		return terr, nil
 	}
 
 	sheets, toolErr2, err := statAndReadMap(absPath)


### PR DESCRIPTION
The handlers in `find.go` and `sheets.go` predated the shared argument-extraction helpers and inlined their own missing/type/ empty-string checks. This routes them through the shared helpers so validation is consistent and no raw `args[...].(string)` assertions remain in either file.

Changes:
- Add `optionalString` helper to `handler.go` for optional string args, returning `(val, present, toolErr)` so callers decide whether an empty string defaults or is rejected
- Migrate required string args (`sheet_id`, `root_title`, `query`, `title`) to `requireString`, deleting the `requireSheetIDFromArgs` and `requireFindTopicTitleArgs` wrappers
- Route optional args (`topic_id`, `parent_id`, scope `sheet_id`, `sheet_title`) through `optionalString`, preserving each site's resolution and default-target logic
- Document the four extraction helpers in `AGENTS.md`

Behavior is preserved except: `query`/`title` wrong-type messages collapse to "expected a non-empty string", a non-string `sheet_title` now errors instead of silently defaulting, and the scope `sheet_id` wrong-type message becomes "expected a string".

Closes #27