### PR TITLE
Drop direct pflag import from main.go

### DIFF
--- a/cmd/xmind-mcp/main.go
+++ b/cmd/xmind-mcp/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/mab-go/xmind-mcp/internal/version"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -34,8 +33,7 @@ var (
 	}
 )
 
-// init registers cobra/viper setup hooks, normalizes global flag names (underscores to
-// hyphens), and configures the version output template.
+// init registers cobra/viper setup hooks and configures the version output template.
 func init() {
 	cobra.OnInitialize(func() {
 		viper.SetEnvPrefix("xmind_mcp")
@@ -46,7 +44,6 @@ func init() {
 		_ = viper.BindPFlag("log-level", cmd.PersistentFlags().Lookup("log-level"))
 	})
 	cmd.PersistentFlags().String("log-level", "info", "log level: debug, info, warn, error")
-	cmd.SetGlobalNormalizationFunc(wordSepNormalizeFunc)
 	cmd.SetVersionTemplate("{{.Version}}\n")
 }
 
@@ -66,12 +63,6 @@ func parseLogLevel(s string) (logging.Level, error) {
 	default:
 		return 0, fmt.Errorf("invalid log level: %q (want debug, info, warn, or error)", s)
 	}
-}
-
-// wordSepNormalizeFunc normalizes flag names by replacing underscores with hyphens.
-func wordSepNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
-	name = strings.ReplaceAll(name, "_", "-")
-	return pflag.NormalizedName(name)
 }
 
 // main runs the root cobra command; on failure it logs a fatal error and exits.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/mab-go/logging v0.1.0
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 )
 
@@ -20,6 +19,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect


### PR DESCRIPTION
AGENTS.md names a single explicit dependency prohibition: `github.com/spf13/pflag` must not be imported directly since it is only a transitive dependency of cobra and viper. `main.go` violated this via `wordSepNormalizeFunc`, wired up through cobra's `SetGlobalNormalizationFunc`, whose callback signature forces naming `pflag` types. That also promoted `pflag` to a direct require in `go.mod`.

The normalization only accepted the undocumented `--log_level` underscore alias for the canonical `--log-level` flag, so it is removed rather than kept behind a documented exception.

Changes:
- Remove the `pflag` import and `wordSepNormalizeFunc` from `main.go`
- Drop the `cmd.SetGlobalNormalizationFunc` call and update the `init` doc comment
- Run `go mod tidy` to move `pflag` to the indirect block in `go.mod`

The `--log-level` flag and the `XMIND_MCP_LOG_LEVEL` env var (handled separately by viper's key replacer) are unaffected.

Closes #43