### PR TITLE
Expand fidelity and atomicity test coverage

### DIFF
--- a/internal/server/handler/find_test.go
+++ b/internal/server/handler/find_test.go
@@ -986,3 +986,43 @@ func TestGetTopicPropertiesMissingTopicID(t *testing.T) {
 		t.Fatal("expected tool error for missing topic_id")
 	}
 }
+
+// TestSetTopicPropertiesPreservesStructureClass pins issue #44 item 3: structureClass
+// must survive a mutating-handler write. Previously it was only ever read back from
+// the unmodified fixture, never across a handler-driven read/edit/write cycle. The
+// Sheet 10 root carries structureClass=org.xmind.ui.map.clockwise; an unrelated
+// SetTopicProperties edit must leave it intact.
+func TestSetTopicPropertiesPreservesStructureClass(t *testing.T) {
+	h := NewXMindHandler()
+	path := copyFixture(t, kitchenSinkPath(t))
+	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet10Title)
+	rootID := rootTopicIDForSheetTitle(t, kitchenSinkSheet10Title)
+
+	const wantStructureClass = "org.xmind.ui.map.clockwise"
+	before, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root := findTopicByID(&findSheetByID(before, sid).RootTopic, rootID); root == nil || root.StructureClass != wantStructureClass {
+		t.Fatalf("fixture precondition: want structureClass %q on root, got %+v", wantStructureClass, root)
+	}
+
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": rootID, "notes": "edited",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+
+	after, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := findTopicByID(&findSheetByID(after, sid).RootTopic, rootID)
+	if root == nil {
+		t.Fatal("root topic missing after mutation")
+	}
+	if root.StructureClass != wantStructureClass {
+		t.Fatalf("structureClass not preserved across write: got %q want %q", root.StructureClass, wantStructureClass)
+	}
+}

--- a/internal/server/handler/handler_test.go
+++ b/internal/server/handler/handler_test.go
@@ -71,6 +71,124 @@ func TestDeepCloneTopicRemapSummaryAndBoundaryIDs(t *testing.T) {
 	assertDeepCloneSummaryDescriptors(t, &clone)
 }
 
+// nestedDetachedCloneFixture builds a topic that exercises clone paths the shallow
+// deepCloneFixtureTopic does not: a detached subtree with a grandchild, and a nested
+// (depth > 0) topic carrying both a boundary descriptor and a summary descriptor that
+// references a summary topic in its own Children.Summary.
+func nestedDetachedCloneFixture() *xmind.Topic {
+	return &xmind.Topic{
+		ID: "root-old",
+		Children: &xmind.Children{
+			Attached: []xmind.Topic{
+				{
+					ID: "a-old",
+					Boundaries: []xmind.Boundary{
+						{ID: "bound-nested-old", Range: "(0,0)"},
+					},
+					Summaries: []xmind.Summary{
+						{ID: "sum-nested-old", Range: "(0,0)", TopicID: "ns-old"},
+					},
+					Children: &xmind.Children{
+						Attached: []xmind.Topic{{ID: "a1-old", Title: "A1"}},
+						Summary:  []xmind.Topic{{ID: "ns-old", Title: "NestedSum"}},
+					},
+				},
+			},
+			Detached: []xmind.Topic{
+				{
+					ID: "d-old",
+					Children: &xmind.Children{
+						Attached: []xmind.Topic{{ID: "d1-old", Title: "D1"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func collectTopicIDs(root *xmind.Topic) []string {
+	var ids []string
+	walkTopics(root, 0, nil, func(t *xmind.Topic, _ int, _ *xmind.Topic) bool {
+		ids = append(ids, t.ID)
+		return true
+	})
+	return ids
+}
+
+func assertAllIDsRemappedAndUnique(t *testing.T, clone *xmind.Topic, oldIDs map[string]bool) {
+	t.Helper()
+	seen := make(map[string]bool)
+	for _, id := range collectTopicIDs(clone) {
+		if oldIDs[id] {
+			t.Fatalf("old topic id %q survived the clone", id)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate topic id after clone: %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func assertDetachedRemapped(t *testing.T, clone *xmind.Topic) {
+	t.Helper()
+	if clone.Children == nil || len(clone.Children.Detached) != 1 {
+		t.Fatalf("expected one detached child, got %+v", clone.Children)
+	}
+	d := clone.Children.Detached[0]
+	if d.ID == "d-old" {
+		t.Fatal("detached topic id should change")
+	}
+	if d.Children == nil || len(d.Children.Attached) != 1 || d.Children.Attached[0].ID == "d1-old" {
+		t.Fatalf("detached grandchild id should change: %+v", d.Children)
+	}
+}
+
+func assertNestedBoundaryRemapped(t *testing.T, a *xmind.Topic) {
+	t.Helper()
+	if len(a.Boundaries) != 1 || a.Boundaries[0].ID == "bound-nested-old" || a.Boundaries[0].Range != "(0,0)" {
+		t.Fatalf("nested boundary not remapped/preserved: %+v", a.Boundaries)
+	}
+}
+
+func assertNestedSummaryRemapped(t *testing.T, a *xmind.Topic) {
+	t.Helper()
+	if len(a.Summaries) != 1 || a.Summaries[0].ID == "sum-nested-old" || a.Summaries[0].Range != "(0,0)" {
+		t.Fatalf("nested summary descriptor not remapped/preserved: %+v", a.Summaries)
+	}
+	if a.Children == nil || len(a.Children.Summary) != 1 || a.Children.Summary[0].ID == "ns-old" {
+		t.Fatalf("nested summary topic id should change: %+v", a.Children)
+	}
+	if a.Summaries[0].TopicID != a.Children.Summary[0].ID {
+		t.Fatalf("nested Summary.TopicID %q should equal nested summary topic id %q",
+			a.Summaries[0].TopicID, a.Children.Summary[0].ID)
+	}
+}
+
+func assertNestedDescriptorsRemapped(t *testing.T, clone *xmind.Topic) {
+	t.Helper()
+	a := &clone.Children.Attached[0]
+	assertNestedBoundaryRemapped(t, a)
+	assertNestedSummaryRemapped(t, a)
+}
+
+// TestDeepCloneTopicDetachedAndNestedDescriptors pins issue #44 item 5: detached
+// descendants are re-ID'd, boundary/summary descriptors on nested (depth > 0)
+// topics are remapped, and a deeply nested Summary.TopicID rewrite stays consistent
+// with its summary topic's new id.
+func TestDeepCloneTopicDetachedAndNestedDescriptors(t *testing.T) {
+	oldIDs := map[string]bool{
+		"root-old": true, "a-old": true, "a1-old": true,
+		"ns-old": true, "d-old": true, "d1-old": true,
+	}
+	clone, err := deepCloneTopic(nestedDetachedCloneFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAllIDsRemappedAndUnique(t, &clone, oldIDs)
+	assertDetachedRemapped(t, &clone)
+	assertNestedDescriptorsRemapped(t, &clone)
+}
+
 // danglingSummaryFixtureTopic builds a topic whose summary descriptor references a topicId that
 // exists nowhere in its subtree (no matching Children.Summary entry).
 func danglingSummaryFixtureTopic() *xmind.Topic {

--- a/internal/server/handler/integration_test.go
+++ b/internal/server/handler/integration_test.go
@@ -191,6 +191,101 @@ func TestIntegration_KitchenSinkPreservation(t *testing.T) {
 	}
 }
 
+// Sheet 14 - Visual Styling carries topics with an unknown sibling key ("style")
+// that is not a typed field, so it round-trips only through the codec's extra bag.
+const (
+	kitchenSinkSheet14Title         = "Sheet 14 - Visual Styling"
+	kitchenSinkSheet14StyledTopicID = "12a82da7-a772-4358-b68c-ffed1100ed7d"
+)
+
+// rawTopicByID parses content.json bytes and returns the topic object with the
+// given id (searching attached/detached/summary), or nil if absent.
+func rawTopicByID(t *testing.T, raw []byte, id string) map[string]any {
+	t.Helper()
+	var sheets []map[string]any
+	if err := json.Unmarshal(raw, &sheets); err != nil {
+		t.Fatalf("unmarshal content.json: %v", err)
+	}
+	var search func(topic map[string]any) map[string]any
+	search = func(topic map[string]any) map[string]any {
+		if topic == nil {
+			return nil
+		}
+		if topic["id"] == id {
+			return topic
+		}
+		children, _ := topic["children"].(map[string]any)
+		for _, key := range []string{"attached", "detached", "summary"} {
+			list, _ := children[key].([]any)
+			for _, c := range list {
+				cm, _ := c.(map[string]any)
+				if found := search(cm); found != nil {
+					return found
+				}
+			}
+		}
+		return nil
+	}
+	for _, sh := range sheets {
+		rt, _ := sh["rootTopic"].(map[string]any)
+		if found := search(rt); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// TestIntegration_EditedTopicPreservesUnknownKeys closes the gap where no test
+// asserted preserved data survives on the *edited* topic itself. It mutates a
+// Sheet 14 topic that carries an unknown sibling key ("style"), then re-reads the
+// raw content.json and asserts both that the mutation applied and that the
+// unknown key survived unchanged on that same topic.
+func TestIntegration_EditedTopicPreservesUnknownKeys(t *testing.T) {
+	h := NewXMindHandler()
+	path := copyFixture(t, kitchenSinkPath(t))
+	sid := kitchenSinkSheetIDByTitle(t, kitchenSinkSheet14Title)
+
+	before := rawTopicByID(t, readZipContentJSON(t, path), kitchenSinkSheet14StyledTopicID)
+	if before == nil {
+		t.Fatalf("styled topic %s not found before mutation", kitchenSinkSheet14StyledTopicID)
+	}
+	styleBefore, ok := before["style"]
+	if !ok {
+		t.Fatal("fixture topic should carry an unknown \"style\" key before mutation")
+	}
+	wantStyle, err := json.Marshal(styleBefore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := callTool(t, h.SetTopicProperties, map[string]any{
+		"path": path, "sheet_id": sid, "topic_id": kitchenSinkSheet14StyledTopicID,
+		"notes": "edited",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+
+	after := rawTopicByID(t, readZipContentJSON(t, path), kitchenSinkSheet14StyledTopicID)
+	if after == nil {
+		t.Fatalf("styled topic %s not found after mutation", kitchenSinkSheet14StyledTopicID)
+	}
+	if after["notes"] == nil {
+		t.Fatal("expected notes mutation to be applied to the edited topic")
+	}
+	styleAfter, ok := after["style"]
+	if !ok {
+		t.Fatal("unknown \"style\" key was dropped from the edited topic")
+	}
+	gotStyle, err := json.Marshal(styleAfter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotStyle) != string(wantStyle) {
+		t.Fatalf("unknown \"style\" key changed across edit:\n before: %s\n after:  %s", wantStyle, gotStyle)
+	}
+}
+
 func assertTopicTitleNotesLabels(t *testing.T, topic *xmind.Topic, wantTitle, wantNote string) {
 	t.Helper()
 	if topic == nil {

--- a/internal/server/handler/mutate_test.go
+++ b/internal/server/handler/mutate_test.go
@@ -1768,6 +1768,128 @@ func TestRenameTopicClearsTitleUnedited(t *testing.T) {
 	}
 }
 
+// setupTitleUneditedMap builds a fresh map with root + attached children A and B,
+// sets titleUnedited=true on A, and persists it. It returns the handler, path,
+// sheet id, root id, and the ids of A and B.
+func setupTitleUneditedMap(t *testing.T) (h *XMindHandler, path, sid, rootID, idA, idB string) {
+	t.Helper()
+	h = NewXMindHandler()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "uned.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid = sheets[0].ID
+	rootID = sheets[0].RootTopic.ID
+	idA = parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "A",
+	})).ID
+	idB = parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "B",
+	})).ID
+	sheets, err = xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topicA := findTopicByID(&sheets[0].RootTopic, idA)
+	if topicA == nil {
+		t.Fatal("topic A missing")
+	}
+	topicA.TitleUnedited = true
+	if err := xmind.WriteMap(path, sheets); err != nil {
+		t.Fatal(err)
+	}
+	return h, path, sid, rootID, idA, idB
+}
+
+// assertTitleUneditedTrue re-reads path and asserts topic idA still carries
+// titleUnedited=true.
+func assertTitleUneditedTrue(t *testing.T, path, idA string) {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topic := findTopicByID(&sheets[0].RootTopic, idA)
+	if topic == nil {
+		t.Fatal("topic A missing after mutation")
+	}
+	if !topic.TitleUnedited {
+		t.Fatalf("titleUnedited not preserved across unrelated mutation: %+v", topic)
+	}
+}
+
+// TestUnrelatedMutationsPreserveTitleUnedited pins issue #44 item 4: an unrelated
+// mutation must not clear titleUnedited. Only the clear-on-rename direction was
+// tested before. Each subtest sets titleUnedited=true on topic A, runs a mutation
+// that does not touch A's title, and asserts the flag survives.
+func TestUnrelatedMutationsPreserveTitleUnedited(t *testing.T) {
+	t.Run("SetTopicProperties", func(t *testing.T) {
+		h, path, sid, _, idA, _ := setupTitleUneditedMap(t)
+		res := callTool(t, h.SetTopicProperties, map[string]any{
+			"path": path, "sheet_id": sid, "topic_id": idA, "notes": "edited",
+		})
+		if res.IsError {
+			t.Fatal(textContent(t, res))
+		}
+		assertTitleUneditedTrue(t, path, idA)
+	})
+
+	t.Run("MoveTopic", func(t *testing.T) {
+		h, path, sid, rootID, idA, _ := setupTitleUneditedMap(t)
+		res := callTool(t, h.MoveTopic, map[string]any{
+			"path": path, "sheet_id": sid, "topic_id": idA, "new_parent_id": rootID, "position": float64(1),
+		})
+		if res.IsError {
+			t.Fatal(textContent(t, res))
+		}
+		assertTitleUneditedTrue(t, path, idA)
+	})
+
+	t.Run("ReorderChildren", func(t *testing.T) {
+		h, path, sid, rootID, idA, idB := setupTitleUneditedMap(t)
+		res := callTool(t, h.ReorderChildren, map[string]any{
+			"path": path, "sheet_id": sid, "parent_id": rootID, "ordered_ids": []any{idB, idA},
+		})
+		if res.IsError {
+			t.Fatal(textContent(t, res))
+		}
+		assertTitleUneditedTrue(t, path, idA)
+	})
+}
+
+// TestAddTopicPersistsTitleUneditedFalse pins the positive direction of issue #44
+// item 4: a freshly created topic must persist titleUnedited=false (absent in JSON
+// via omitempty, read back as the zero value), confirming AddTopic never sets it.
+func TestAddTopicPersistsTitleUneditedFalse(t *testing.T) {
+	h := NewXMindHandler()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unedfalse.xmind")
+	callTool(t, h.CreateMap, map[string]any{"path": path, "root_title": "R"})
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid := sheets[0].ID
+	rootID := sheets[0].RootTopic.ID
+	tid := parseAddTopicResult(t, callTool(t, h.AddTopic, map[string]any{
+		"path": path, "sheet_id": sid, "parent_id": rootID, "title": "Child",
+	})).ID
+	sheets, err = xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topic := findTopicByID(&sheets[0].RootTopic, tid)
+	if topic == nil {
+		t.Fatal("created topic missing")
+	}
+	if topic.TitleUnedited {
+		t.Fatalf("freshly created topic should persist titleUnedited=false, got %+v", topic)
+	}
+}
+
 func TestMoveTopicToPosition(t *testing.T) {
 	h := NewXMindHandler()
 	dir := t.TempDir()

--- a/internal/xmind/writer_test.go
+++ b/internal/xmind/writer_test.go
@@ -3,6 +3,7 @@ package xmind
 import (
 	"archive/zip"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -127,6 +128,7 @@ func TestWriteMapAtomicSafetyOnFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	before := fileSHA256(t, dst)
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 	if err := os.Chmod(dir, 0o555); err != nil {
 		t.Fatal(err)
@@ -134,6 +136,52 @@ func TestWriteMapAtomicSafetyOnFailure(t *testing.T) {
 	err = WriteMap(dst, sheets)
 	if err == nil {
 		t.Fatal("expected WriteMap to fail when temp dir is not writable")
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		if strings.HasPrefix(e.Name(), ".xmind-tmp-") {
+			t.Fatalf("leaked temp file: %s", e.Name())
+		}
+	}
+	if after := fileSHA256(t, dst); after != before {
+		t.Fatalf("original file changed after a failed write: before %s, after %s", before, after)
+	}
+}
+
+// TestWriteMapPreservesOriginalOnSwapFailure exercises the full atomic path: the
+// temp file is written successfully, but the final swap-into-place fails. The
+// original destination must be left byte-identical and no temp residue may
+// remain. The chmod-based test above blocks temp-file creation, so the swap step
+// never runs there; this test forces a failure at the swap by injecting a rename
+// error via the osRename seam.
+func TestWriteMapPreservesOriginalOnSwapFailure(t *testing.T) {
+	src := kitchenSinkPath(t)
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	sheets, err := ReadMap(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := fileSHA256(t, dst)
+
+	orig := osRename
+	t.Cleanup(func() { osRename = orig })
+	osRename = func(string, string) error {
+		return errors.New("injected swap failure")
+	}
+
+	if err := WriteMap(dst, sheets); err == nil {
+		t.Fatal("expected WriteMap to fail when the swap rename fails")
+	}
+
+	if after := fileSHA256(t, dst); after != before {
+		t.Fatalf("original file changed after a failed swap: before %s, after %s", before, after)
 	}
 	ents, err := os.ReadDir(dir)
 	if err != nil {


### PR DESCRIPTION
Several core invariants from AGENTS.md were protected only at the codec layer or asserted only against the unmodified fixture, never across an actual mutating-handler write. A regression that dropped a protected field, stripped `structureClass`, or corrupted the original file on a failed write would have passed the suite. These tests pin each invariant end-to-end. Test-only change; no production code is touched.

Changes:
- Harden `TestWriteMapAtomicSafetyOnFailure` with a `fileSHA256` before/after check, and add `TestWriteMapPreservesOriginalOnSwapFailure` that forces a failure at the swap step via the `osRename` seam to verify the original survives byte-identical with no temp residue
- Add `TestIntegration_EditedTopicPreservesUnknownKeys` asserting an unknown sibling key survives a handler edit on the edited topic
- Add `TestSetTopicPropertiesPreservesStructureClass` covering `structureClass` survival across a handler write
- Add `TestUnrelatedMutationsPreserveTitleUnedited` (SetTopicProperties, MoveTopic, ReorderChildren) and `TestAddTopicPersistsTitleUneditedFalse`
- Add `TestDeepCloneTopicDetachedAndNestedDescriptors` with a dedicated fixture exercising detached re-ID, nested descriptor remapping, and deeply nested `Summary.TopicID` consistency

Closes #44