### PR TITLE
Open xmind file once per mutation via MapWriter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,9 @@ internal/
   xmind/
     types.go              — Go structs mirroring the content.json schema
     json_codec.go         — custom JSON: preserve unknown keys, notes shape
-    reader.go             — open zip, parse content.json → []Sheet
-    writer.go             — serialize []Sheet → content.json, write back to zip
+    reader.go             — open zip, parse content.json → []Sheet (ReadMap, parseContentFromZip)
+    writer.go             — serialize []Sheet → content.json, write back to zip (WriteMap, writeMapBody)
+    update.go             — OpenMapForUpdate/MapWriter: single-open read-then-commit handle for mutations
     atomic_replace.go     — replaceTempFile/replaceViaBackup: atomic replace (backup-restore on Windows)
     defaults.go           — DefaultTheme and DefaultSheetExtensions for new maps
     default_theme.json    — embedded default theme blob (sourced from kitchen-sink fixture)
@@ -104,6 +105,8 @@ Every mutating tool call follows this exact pattern — do not deviate from it:
 
 **Atomicity is required.** Always write to a temp file first and rename/swap on success. If a write fails mid-way, the original file must be left untouched. There is no session state and no temp files left behind on failure.
 
+**Single-open mutation path.** Mutating handlers open the `.xmind` once via `xmind.OpenMapForUpdate` (through the `statAndOpenMapForUpdate` / `loadSheet…ForUpdate` helpers), which returns the parsed `[]Sheet` plus a `*xmind.MapWriter` that keeps the zip reader open. The handler mutates the sheets in memory and calls `mw.Commit(sheets)` to persist them, raw-copying the still-open non-`content.json` entries (steps 1–5 above happen across one file open instead of two). `Commit` closes the read handle *before* the atomic swap, so on Windows the swap runs with no open handle on the original. `Commit` is single-use (a second `Commit`, or one after `Close`, errors). The free-standing `xmind.WriteMap` (which re-reads the file fresh) is retained for tests and any read-fresh caller; `xmind.CreateNewMap` writes brand-new maps. The temp-then-swap mechanics below are unchanged and shared by both `WriteMap` and `Commit` via the internal `writeMapBody`.
+
 The temp-then-swap happens in `replaceTempFile` (`internal/xmind/atomic_replace.go`). On Unix, `os.Rename` atomically replaces the destination. On Windows, `os.Rename` cannot overwrite an existing file, so `replaceViaBackup` moves the original aside to a uniquely named backup first, renames the temp into place, then removes the backup — restoring the backup if the rename fails. This keeps the original recoverable on Windows; never reintroduce a plain remove-then-rename there, which can destroy the original if the rename fails.
 
 ### `content.json` fidelity (unknown keys)
@@ -112,7 +115,7 @@ Major JSON object types in the workbook tree use custom `MarshalJSON` / `Unmarsh
 
 When you add a **new first-class field** to `Sheet`, `Topic`, `Children`, `Relationship`, `Boundary`, the summary-range `Summary`, `Marker`, `Position`, `TopicImage`, `AttributedTitleItem`, `Notes`, or `NoteContent`, you **must** add the JSON key to the corresponding allowlist in `json_codec.go` (e.g. `topicKnownKeys`, `sheetKnownKeys`, or the `deleteKeys(...)` list for that type — `Notes` uses `"plain"`/`"realHTML"`, `NoteContent` uses `"content"`). Otherwise the new field will be treated as opaque preserved data and will not populate the typed field.
 
-**Limitation:** Sibling keys on each **`Extension`** object (alongside `provider`, `content`, `resourceRefs`) are still dropped. Non–`content.json` zip entries continue to be preserved by `WriteMap` via raw copy.
+**Limitation:** Sibling keys on each **`Extension`** object (alongside `provider`, `content`, `resourceRefs`) are still dropped. Non–`content.json` zip entries continue to be preserved by `WriteMap` and `MapWriter.Commit` via raw copy.
 
 **String encoding:** When persisting `content.json`, use **`xmind.WriteMap`** / **`xmind.CreateNewMap`** only. They marshal with `encoding/json` HTML escaping disabled so characters such as `&`, `<`, and `>` appear literally in JSON strings (matching XMind on-disk files). Do not use `json.Marshal` on `[]Sheet` for that payload; default marshaling can rewrite `json.Marshaler` output in ways XMind mishandles.
 
@@ -169,12 +172,37 @@ if toolErr != nil {
 // statAndReadMap checks existence, reads the zip, and parses content.json.
 // toolErr is non-nil for caller-fixable conditions (file not found, bad zip).
 // err is non-nil for unexpected I/O or environment failures.
+// Use this in read-only handlers (find/list/get); it closes the file immediately.
 sheets, toolErr, err := statAndReadMap(absPath)
 if toolErr != nil {
     return toolErr, nil
 }
 if err != nil {
     return nil, err
+}
+```
+
+**Mutating handlers** instead use `statAndOpenMapForUpdate` (or the `loadSheet…ForUpdate`
+helpers in `mutate.go`), which open the file once and return a `*xmind.MapWriter` so the
+write reuses the same open handle (see Read/Write Lifecycle). The mandatory rule: `defer
+mw.Close()` **immediately** after the protocol-error check — before any branch that may
+return without committing (a sheet/topic-not-found tool error, or the no-change path in
+`FindAndReplace`). `mw.Close()` is idempotent and nil-safe (the open helpers return a nil
+writer on a file-not-found tool error, which `defer mw.Close()` tolerates), and it is a
+no-op after a successful `mw.Commit`.
+
+```go
+sheets, mw, toolErr, err := statAndOpenMapForUpdate(absPath)
+if err != nil {
+    return nil, err
+}
+defer func() { _ = mw.Close() }()
+if toolErr != nil {
+    return toolErr, nil
+}
+// …mutate sheets…
+if err := mw.Commit(sheets); err != nil {
+    return nil, fmt.Errorf("write map: %w", err)
 }
 ```
 

--- a/internal/server/handler/handler.go
+++ b/internal/server/handler/handler.go
@@ -340,3 +340,22 @@ func statAndReadMap(absPath string) (sheets []xmind.Sheet, toolErr *mcp.CallTool
 	}
 	return sheets, nil, nil
 }
+
+// statAndOpenMapForUpdate is the mutating-handler counterpart to statAndReadMap: it
+// checks that absPath exists, opens the workbook once, and returns a MapWriter that holds
+// the zip open for a subsequent mw.Commit. Error mapping matches statAndReadMap. Callers
+// MUST defer mw.Close() immediately after a nil-error return, before any branch that may
+// return without committing (e.g. a sheet-not-found tool error or a no-change path).
+func statAndOpenMapForUpdate(absPath string) (sheets []xmind.Sheet, mw *xmind.MapWriter, toolErr *mcp.CallToolResult, err error) {
+	if _, statErr := os.Stat(absPath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil, nil, mcp.NewToolResultError(fmt.Sprintf("file not found: %s", absPath)), nil
+		}
+		return nil, nil, nil, fmt.Errorf("stat file: %w", statErr)
+	}
+	sheets, mw, openErr := xmind.OpenMapForUpdate(absPath)
+	if openErr != nil {
+		return nil, nil, mcp.NewToolResultError(openErr.Error()), nil
+	}
+	return sheets, mw, nil, nil
+}

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -456,10 +456,11 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 		return perr, nil
 	}
 
-	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
+	sheets, mw, sh, parent, mapErr, err := loadSheetAndParentTopicForUpdate(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if mapErr != nil {
 		return mapErr, nil
 	}
@@ -476,7 +477,7 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 		return terr, nil
 	}
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return jsonResult(addTopicResponse{
@@ -514,10 +515,11 @@ func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolReque
 		return perr, nil
 	}
 
-	sheets, sh, tErr, err := loadSheetByID(absPath, sheetID)
+	sheets, mw, sh, tErr, err := loadSheetByIDForUpdate(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if tErr != nil {
 		return tErr, nil
 	}
@@ -538,7 +540,7 @@ func (h *XMindHandler) DuplicateTopic(ctx context.Context, req mcp.CallToolReque
 		return terr, nil
 	}
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return jsonResult(duplicateTopicResponse{
@@ -577,10 +579,11 @@ func (h *XMindHandler) AddTopicsBulk(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError("invalid argument topics: " + perr.Error()), nil
 	}
 
-	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
+	sheets, mw, sh, parent, mapErr, err := loadSheetAndParentTopicForUpdate(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if mapErr != nil {
 		return mapErr, nil
 	}
@@ -593,7 +596,7 @@ func (h *XMindHandler) AddTopicsBulk(ctx context.Context, req mcp.CallToolReques
 		rootIDs[i] = topics[i].ID
 	}
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return jsonResult(addTopicsBulkResponse{
@@ -626,10 +629,11 @@ func (h *XMindHandler) RenameTopic(ctx context.Context, req mcp.CallToolRequest)
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -645,7 +649,7 @@ func (h *XMindHandler) RenameTopic(ctx context.Context, req mcp.CallToolRequest)
 	topic.Title = title
 	topic.TitleUnedited = false
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("renamed topic %s", topicID)), nil
@@ -680,10 +684,11 @@ func (h *XMindHandler) DeleteTopic(ctx context.Context, req mcp.CallToolRequest)
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -695,7 +700,7 @@ func (h *XMindHandler) DeleteTopic(ctx context.Context, req mcp.CallToolRequest)
 		return rerr, nil
 	}
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("deleted topic %s", topicID)), nil
@@ -771,10 +776,11 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 		return aerr, nil
 	}
 
-	sheets, sh, topic, _, ctxErr, err := loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID)
+	sheets, mw, sh, topic, ctxErr, err := loadSheetMoveSubjectsForUpdate(absPath, sheetID, topicID, newParentID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if ctxErr != nil {
 		return ctxErr, nil
 	}
@@ -793,7 +799,7 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 	}
 
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return jsonResult(moveTopicResponse{
@@ -804,27 +810,12 @@ func (h *XMindHandler) MoveTopic(ctx context.Context, req mcp.CallToolRequest) (
 	})
 }
 
-func loadSheetParentTopic(absPath, sheetID, parentID string) ([]xmind.Sheet, *xmind.Sheet, *xmind.Topic, *mcp.CallToolResult, error) {
-	sheets, toolErr2, err := statAndReadMap(absPath)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	if toolErr2 != nil {
-		return nil, nil, nil, toolErr2, nil
-	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return sheets, nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	parent := findTopicByID(&sh.RootTopic, parentID)
-	if parent == nil {
-		return sheets, sh, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
-	}
-	return sheets, sh, parent, nil, nil
-}
-
-func loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID string) ([]xmind.Sheet, *xmind.Sheet, *xmind.Topic, *xmind.Topic, *mcp.CallToolResult, error) {
-	sheets, toolErr2, err := statAndReadMap(absPath)
+// loadSheetMoveSubjectsForUpdate opens the map for update, resolves the moved topic, and
+// validates that newParentID exists. The resolved new-parent pointer is intentionally not
+// returned: detachTopicFromTree can invalidate it, so MoveTopic re-resolves it after the
+// detach via attachDetachedToParent. The Close contract matches loadSheetByIDForUpdate.
+func loadSheetMoveSubjectsForUpdate(absPath, sheetID, topicID, newParentID string) ([]xmind.Sheet, *xmind.MapWriter, *xmind.Sheet, *xmind.Topic, *mcp.CallToolResult, error) {
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -833,17 +824,16 @@ func loadSheetMoveSubjects(absPath, sheetID, topicID, newParentID string) ([]xmi
 	}
 	sh := findSheetByID(sheets, sheetID)
 	if sh == nil {
-		return sheets, nil, nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+		return sheets, mw, nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
 	}
 	topic := findTopicByID(&sh.RootTopic, topicID)
 	if topic == nil {
-		return sheets, sh, nil, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
+		return sheets, mw, sh, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", topicID)), nil
 	}
-	newParent := findTopicByID(&sh.RootTopic, newParentID)
-	if newParent == nil {
-		return sheets, sh, topic, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", newParentID)), nil
+	if findTopicByID(&sh.RootTopic, newParentID) == nil {
+		return sheets, mw, sh, topic, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", newParentID)), nil
 	}
-	return sheets, sh, topic, newParent, nil, nil
+	return sheets, mw, sh, topic, nil, nil
 }
 
 func parseOrderedIDs(rawIDs []any) ([]string, *mcp.CallToolResult) {
@@ -920,10 +910,11 @@ func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequ
 		return aerr, nil
 	}
 
-	sheets, sh, parent, ctxErr, err := loadSheetParentTopic(absPath, sheetID, parentID)
+	sheets, mw, sh, parent, ctxErr, err := loadSheetAndParentTopicForUpdate(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if ctxErr != nil {
 		return ctxErr, nil
 	}
@@ -934,7 +925,7 @@ func (h *XMindHandler) ReorderChildren(ctx context.Context, req mcp.CallToolRequ
 
 	parent.Children.Attached = newOrder
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("reordered %d children under %s", len(newOrder), parentID)), nil
@@ -1174,36 +1165,40 @@ func resolveTopicsForSheet(root *xmind.Topic, topicIDs []string) ([]*xmind.Topic
 	return topics, nil
 }
 
-// loadSheetByID reads the map and returns the sheet with sheetID, or a tool/protocol error.
-func loadSheetByID(absPath, sheetID string) ([]xmind.Sheet, *xmind.Sheet, *mcp.CallToolResult, error) {
-	sheets, toolErr2, err := statAndReadMap(absPath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if toolErr2 != nil {
-		return nil, nil, toolErr2, nil
-	}
-	sh := findSheetByID(sheets, sheetID)
-	if sh == nil {
-		return nil, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
-	}
-	return sheets, sh, nil, nil
-}
-
-// loadSheetAndParentTopic loads the map and resolves parentID under the sheet root.
-func loadSheetAndParentTopic(absPath, sheetID, parentID string) ([]xmind.Sheet, *xmind.Sheet, *xmind.Topic, *mcp.CallToolResult, error) {
-	sheets, sh, tErr, err := loadSheetByID(absPath, sheetID)
+// loadSheetByIDForUpdate opens the map for update and resolves the sheet with sheetID.
+// The caller must defer mw.Close() right after the err check. mw is non-nil for a post-open
+// tool error (sheet not found) and nil when the open itself failed (a file-not-found tool
+// error or a protocol error); mw.Close is nil-safe, so the defer is safe either way.
+func loadSheetByIDForUpdate(absPath, sheetID string) ([]xmind.Sheet, *xmind.MapWriter, *xmind.Sheet, *mcp.CallToolResult, error) {
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	if toolErr2 != nil {
+		return nil, nil, nil, toolErr2, nil
+	}
+	sh := findSheetByID(sheets, sheetID)
+	if sh == nil {
+		return sheets, mw, nil, mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
+	}
+	return sheets, mw, sh, nil, nil
+}
+
+// loadSheetAndParentTopicForUpdate opens the map for update and resolves parentID under the
+// sheet root. The same Close contract as loadSheetByIDForUpdate applies.
+func loadSheetAndParentTopicForUpdate(absPath, sheetID, parentID string) ([]xmind.Sheet, *xmind.MapWriter, *xmind.Sheet, *xmind.Topic, *mcp.CallToolResult, error) {
+	sheets, mw, sh, tErr, err := loadSheetByIDForUpdate(absPath, sheetID)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
 	if tErr != nil {
-		return nil, nil, nil, tErr, nil
+		return sheets, mw, nil, nil, tErr, nil
 	}
 	parent := findTopicByID(&sh.RootTopic, parentID)
 	if parent == nil {
-		return sheets, sh, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
+		return sheets, mw, sh, nil, mcp.NewToolResultError(fmt.Sprintf("topic not found: %s", parentID)), nil
 	}
-	return sheets, sh, parent, nil, nil
+	return sheets, mw, sh, parent, nil, nil
 }
 
 func parseBulkTopicsArray(args map[string]any) ([]any, *mcp.CallToolResult) {
@@ -1284,10 +1279,11 @@ func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolR
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -1305,7 +1301,7 @@ func (h *XMindHandler) SetTopicProperties(ctx context.Context, req mcp.CallToolR
 	}
 
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("updated topic %s", topicID)), nil
@@ -1333,10 +1329,11 @@ func (h *XMindHandler) SetTopicPropertiesBulk(ctx context.Context, req mcp.CallT
 		return mcp.NewToolResultError("missing property updates: provide at least one of notes, labels, markers, remove_markers, or link"), nil
 	}
 
-	sheets, sh, sheetErr, err := loadSheetByID(absPath, sheetID)
+	sheets, mw, sh, sheetErr, err := loadSheetByIDForUpdate(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if sheetErr != nil {
 		return sheetErr, nil
 	}
@@ -1351,7 +1348,7 @@ func (h *XMindHandler) SetTopicPropertiesBulk(ctx context.Context, req mcp.CallT
 	}
 
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("updated %d topics", len(topicIDs))), nil
@@ -1374,10 +1371,11 @@ func (h *XMindHandler) AddFloatingTopic(ctx context.Context, req mcp.CallToolReq
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -1398,7 +1396,7 @@ func (h *XMindHandler) AddFloatingTopic(ctx context.Context, req mcp.CallToolReq
 	ch := ensureChildren(root)
 	ch.Detached = append(ch.Detached, topic)
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("added floating topic id %s", topic.ID)), nil
@@ -1429,10 +1427,11 @@ func (h *XMindHandler) AddRelationship(ctx context.Context, req mcp.CallToolRequ
 		return oerr, nil
 	}
 
-	sheets, sh, tErr, err := loadSheetByID(absPath, sheetID)
+	sheets, mw, sh, tErr, err := loadSheetByIDForUpdate(absPath, sheetID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if tErr != nil {
 		return tErr, nil
 	}
@@ -1442,7 +1441,7 @@ func (h *XMindHandler) AddRelationship(ctx context.Context, req mcp.CallToolRequ
 
 	relID := appendRelationship(sh, fromID, toID, label)
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("added relationship id %s", relID)), nil
@@ -1465,10 +1464,11 @@ func (h *XMindHandler) DeleteRelationship(ctx context.Context, req mcp.CallToolR
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -1483,7 +1483,7 @@ func (h *XMindHandler) DeleteRelationship(ctx context.Context, req mcp.CallToolR
 	}
 	sh.Relationships = slices.Delete(sh.Relationships, idx, idx+1)
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("deleted relationship id %s", relationshipID)), nil
@@ -1515,10 +1515,11 @@ func (h *XMindHandler) AddSummary(ctx context.Context, req mcp.CallToolRequest) 
 		return oerr, nil
 	}
 
-	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
+	sheets, mw, sh, parent, mapErr, err := loadSheetAndParentTopicForUpdate(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if mapErr != nil {
 		return mapErr, nil
 	}
@@ -1529,7 +1530,7 @@ func (h *XMindHandler) AddSummary(ctx context.Context, req mcp.CallToolRequest) 
 	summaryTopicID := applyAddSummary(parent, fromIdx, toIdx, title)
 
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("added summary topic id %s", summaryTopicID)), nil
@@ -1556,10 +1557,11 @@ func (h *XMindHandler) AddBoundary(ctx context.Context, req mcp.CallToolRequest)
 		return oerr, nil
 	}
 
-	sheets, sh, parent, mapErr, err := loadSheetAndParentTopic(absPath, sheetID, parentID)
+	sheets, mw, sh, parent, mapErr, err := loadSheetAndParentTopicForUpdate(absPath, sheetID, parentID)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if mapErr != nil {
 		return mapErr, nil
 	}
@@ -1576,7 +1578,7 @@ func (h *XMindHandler) AddBoundary(ctx context.Context, req mcp.CallToolRequest)
 	parent.Boundaries = append(parent.Boundaries, b)
 
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("added boundary id %s", boundaryID)), nil

--- a/internal/server/handler/sheets.go
+++ b/internal/server/handler/sheets.go
@@ -290,10 +290,11 @@ func (h *XMindHandler) AddSheet(ctx context.Context, req mcp.CallToolRequest) (*
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -301,7 +302,7 @@ func (h *XMindHandler) AddSheet(ctx context.Context, req mcp.CallToolRequest) (*
 	bumpAllSheetsRevisionID(sheets)
 	sh := newSheet(sheetTitle, rootTitle)
 	sheets = append(sheets, sh)
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 
@@ -322,10 +323,11 @@ func (h *XMindHandler) DeleteSheet(ctx context.Context, req mcp.CallToolRequest)
 		return terr, nil
 	}
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
@@ -341,7 +343,7 @@ func (h *XMindHandler) DeleteSheet(ctx context.Context, req mcp.CallToolRequest)
 
 	sheets = slices.Delete(sheets, idx, idx+1)
 	bumpAllSheetsRevisionID(sheets)
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 

--- a/internal/server/handler/update_integration_test.go
+++ b/internal/server/handler/update_integration_test.go
@@ -1,0 +1,122 @@
+package handler
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/mab-go/xmind-mcp/internal/xmind"
+)
+
+// firstSheetID returns the ID of the first sheet in the map at path.
+func firstSheetID(t *testing.T, path string) string {
+	t.Helper()
+	sheets, err := xmind.ReadMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sheets) == 0 {
+		t.Fatal("no sheets")
+	}
+	return sheets[0].ID
+}
+
+// zipEntryNamesAt returns the sorted entry-name set of the zip at path.
+func zipEntryNamesAt(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	st, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	zr, err := zip.NewReader(f, st.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(zr.File))
+	for _, zf := range zr.File {
+		names = append(names, zf.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// TestIntegration_FindAndReplaceNoMatchClosesCleanly exercises the conditional-write path:
+// FindAndReplace opens the map for update but commits nothing when there are no matches.
+// The defer mw.Close() must still release the handle, so a later mutation on the same path
+// succeeds and the file is left byte-identical by the no-op call.
+func TestIntegration_FindAndReplaceNoMatchClosesCleanly(t *testing.T) {
+	h := NewXMindHandler()
+	path := copyFixture(t, kitchenSinkPath(t))
+
+	before := readZipContentJSON(t, path)
+	res := callTool(t, h.FindAndReplace, map[string]any{
+		"path": path, "find": "zzz_no_such_text_zzz", "replace": "x",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	var resp struct {
+		ChangedCount int `json:"changedCount"`
+	}
+	if err := json.Unmarshal([]byte(textContent(t, res)), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ChangedCount != 0 {
+		t.Fatalf("expected 0 changes, got %d", resp.ChangedCount)
+	}
+	if after := readZipContentJSON(t, path); !bytes.Equal(before, after) {
+		t.Fatal("no-match FindAndReplace must not modify content.json")
+	}
+
+	// A subsequent mutation on the same path must succeed (proves the handle was released).
+	mres := callTool(t, h.AddFloatingTopic, map[string]any{
+		"path": path, "sheet_id": firstSheetID(t, path), "title": "AfterNoOp",
+	})
+	if mres.IsError {
+		t.Fatal(textContent(t, mres))
+	}
+}
+
+// TestIntegration_MutateBadSheetIDToolError exercises the post-open tool-error path: the map
+// opens for update but the sheet lookup fails. The handler must return a sheet-not-found tool
+// error (its deferred mw.Close releases the handle without committing).
+func TestIntegration_MutateBadSheetIDToolError(t *testing.T) {
+	h := NewXMindHandler()
+	path := copyFixture(t, kitchenSinkPath(t))
+
+	res := callTool(t, h.RenameTopic, map[string]any{
+		"path": path, "sheet_id": "no-such-sheet", "topic_id": kitchenSinkAlphaTopicID, "title": "X",
+	})
+	if !res.IsError {
+		t.Fatal("expected a tool error for an unknown sheet_id")
+	}
+	if msg := textContent(t, res); !bytes.Contains([]byte(msg), []byte("sheet not found")) {
+		t.Fatalf("expected sheet-not-found tool error, got: %s", msg)
+	}
+}
+
+// TestIntegration_CommitPreservesZipEntries asserts the single-open Commit path preserves the
+// full set of non-content.json zip entries (embedded resources) through a handler mutation.
+func TestIntegration_CommitPreservesZipEntries(t *testing.T) {
+	h := NewXMindHandler()
+	path := copyFixture(t, kitchenSinkPath(t))
+	before := zipEntryNamesAt(t, path)
+
+	res := callTool(t, h.RenameTopic, map[string]any{
+		"path": path, "sheet_id": firstSheetID(t, path), "topic_id": kitchenSinkAlphaTopicID, "title": "EntriesPreserved",
+	})
+	if res.IsError {
+		t.Fatal(textContent(t, res))
+	}
+	if after := zipEntryNamesAt(t, path); !slices.Equal(before, after) {
+		t.Fatalf("zip entry set changed:\nbefore: %v\nafter:  %v", before, after)
+	}
+}

--- a/internal/server/handler/utils.go
+++ b/internal/server/handler/utils.go
@@ -176,18 +176,19 @@ func (h *XMindHandler) ImportFromOutline(ctx context.Context, req mcp.CallToolRe
 
 	normalizeOutlineDepths(pairs)
 
-	sheets, toolErr2, err := statAndReadMap(absPath)
+	sheets, mw, toolErr2, err := statAndOpenMapForUpdate(absPath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
 
 	if sheetIDArg == "" {
-		return importOutlineNewSheet(absPath, sheets, pairs)
+		return importOutlineNewSheet(mw, sheets, pairs)
 	}
-	return importOutlineAppend(absPath, sheets, sheetIDArg, parentIDArg, pairs)
+	return importOutlineAppend(mw, sheets, sheetIDArg, parentIDArg, pairs)
 }
 
 func parseImportOutlineSheetArgs(args map[string]any) (sheetID, parentID string, toolErr *mcp.CallToolResult) {
@@ -204,7 +205,7 @@ func parseImportOutlineSheetArgs(args map[string]any) (sheetID, parentID string,
 }
 
 // importOutlineNewSheet: single tree; first line is sheet+root title; extra depth-0 lines are children of root.
-func importOutlineNewSheet(absPath string, sheets []xmind.Sheet, pairs []outlinePair) (*mcp.CallToolResult, error) {
+func importOutlineNewSheet(mw *xmind.MapWriter, sheets []xmind.Sheet, pairs []outlinePair) (*mcp.CallToolResult, error) {
 	root := buildOutlineTreeSingleRoot(pairs)
 	if root == nil {
 		return mcp.NewToolResultError("could not build outline tree"), nil
@@ -216,14 +217,14 @@ func importOutlineNewSheet(absPath string, sheets []xmind.Sheet, pairs []outline
 		ch.Attached = append(ch.Attached, outlineNodeToTopics(c))
 	}
 	sheets = append(sheets, sh)
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	n := countTopics(&sh.RootTopic)
 	return textResult(fmt.Sprintf("imported %d topics into new sheet id %s", n, sh.ID)), nil
 }
 
-func importOutlineAppend(absPath string, sheets []xmind.Sheet, sheetID, parentID string, pairs []outlinePair) (*mcp.CallToolResult, error) {
+func importOutlineAppend(mw *xmind.MapWriter, sheets []xmind.Sheet, sheetID, parentID string, pairs []outlinePair) (*mcp.CallToolResult, error) {
 	sh := findSheetByID(sheets, sheetID)
 	if sh == nil {
 		return mcp.NewToolResultError(fmt.Sprintf("sheet not found: %s", sheetID)), nil
@@ -246,7 +247,7 @@ func importOutlineAppend(absPath string, sheets []xmind.Sheet, sheetID, parentID
 		total += countTopics(&t)
 	}
 	sh.RevisionID = uuid.New().String()
-	if err := xmind.WriteMap(absPath, sheets); err != nil {
+	if err := mw.Commit(sheets); err != nil {
 		return nil, fmt.Errorf("write map: %w", err)
 	}
 	return textResult(fmt.Sprintf("imported %d topics", total)), nil
@@ -550,16 +551,21 @@ func parseFindAndReplaceInputs(args map[string]any) (absPath, findStr, replaceSt
 	return absPath, findStr, replaceStr, exact, toolErr
 }
 
-func findAndReplaceLoadSheets(absPath string, args map[string]any) (sheets []xmind.Sheet, sheetsToUpdate []*xmind.Sheet, toolErr *mcp.CallToolResult, err error) {
-	sheets, toolErr, err = statAndReadMap(absPath)
+// findAndReplaceLoadSheets opens the map for update and resolves the sheets to scan.
+// The caller must defer mw.Close() right after the err check (FindAndReplace may finish
+// without committing when there are no changes). mw is non-nil for a post-open tool error
+// and nil when the open itself failed (a file-not-found tool error or a protocol error);
+// mw.Close is nil-safe, so the defer is safe either way.
+func findAndReplaceLoadSheets(absPath string, args map[string]any) (sheets []xmind.Sheet, mw *xmind.MapWriter, sheetsToUpdate []*xmind.Sheet, toolErr *mcp.CallToolResult, err error) {
+	sheets, mw, toolErr, err = statAndOpenMapForUpdate(absPath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if toolErr != nil {
-		return nil, nil, toolErr, nil
+		return nil, nil, nil, toolErr, nil
 	}
 	sheetsToUpdate, toolErr = sheetsToUpdateForFindReplace(args, sheets)
-	return sheets, sheetsToUpdate, toolErr, nil
+	return sheets, mw, sheetsToUpdate, toolErr, nil
 }
 
 func findReplaceRunOnSheets(sheetsToUpdate []*xmind.Sheet, findStr, replaceStr string, exact bool) []findReplaceChange {
@@ -575,7 +581,7 @@ func findReplaceRunOnSheets(sheetsToUpdate []*xmind.Sheet, findStr, replaceStr s
 	return changes
 }
 
-func finishFindReplace(absPath string, sheets []xmind.Sheet, changes []findReplaceChange) (*mcp.CallToolResult, error) {
+func finishFindReplace(mw *xmind.MapWriter, sheets []xmind.Sheet, changes []findReplaceChange) (*mcp.CallToolResult, error) {
 	resp := struct {
 		ChangedCount int                 `json:"changedCount"`
 		Changes      []findReplaceChange `json:"changes"`
@@ -585,7 +591,7 @@ func finishFindReplace(absPath string, sheets []xmind.Sheet, changes []findRepla
 		return nil, fmt.Errorf("marshal find_and_replace response: %w", err)
 	}
 	if len(changes) > 0 {
-		if err := xmind.WriteMap(absPath, sheets); err != nil {
+		if err := mw.Commit(sheets); err != nil {
 			return nil, fmt.Errorf("write map: %w", err)
 		}
 	}
@@ -600,15 +606,16 @@ func (h *XMindHandler) FindAndReplace(ctx context.Context, req mcp.CallToolReque
 	if toolErr != nil {
 		return toolErr, nil
 	}
-	sheets, sheetsToUpdate, toolErr2, err := findAndReplaceLoadSheets(absPath, args)
+	sheets, mw, sheetsToUpdate, toolErr2, err := findAndReplaceLoadSheets(absPath, args)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = mw.Close() }()
 	if toolErr2 != nil {
 		return toolErr2, nil
 	}
 	changes := findReplaceRunOnSheets(sheetsToUpdate, findStr, replaceStr, exact)
-	return finishFindReplace(absPath, sheets, changes)
+	return finishFindReplace(mw, sheets, changes)
 }
 
 func stringArgAllowEmpty(args map[string]any, key string) (string, *mcp.CallToolResult) {

--- a/internal/xmind/reader.go
+++ b/internal/xmind/reader.go
@@ -5,27 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 )
 
 // ReadMap opens a .xmind zip, reads content.json, and unmarshals it into sheets.
 func ReadMap(path string) ([]Sheet, error) {
-	f, err := os.Open(path)
+	zr, f, err := openZipReaderAtPath(path)
 	if err != nil {
-		return nil, fmt.Errorf("open xmind file: %w", err)
+		return nil, err
 	}
 	defer func() { _ = f.Close() }()
 
-	st, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat xmind file: %w", err)
-	}
+	return parseContentFromZip(zr)
+}
 
-	zr, err := zip.NewReader(f, st.Size())
-	if err != nil {
-		return nil, fmt.Errorf("read zip: %w", err)
-	}
-
+// parseContentFromZip locates content.json in zr, reads it, and unmarshals it into sheets.
+func parseContentFromZip(zr *zip.Reader) ([]Sheet, error) {
 	var contentEntry *zip.File
 	for _, zf := range zr.File {
 		if zf.Name == "content.json" {

--- a/internal/xmind/update.go
+++ b/internal/xmind/update.go
@@ -1,0 +1,78 @@
+package xmind
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+)
+
+// MapWriter holds an open read handle on a .xmind file so a single mutate-then-commit
+// cycle reuses one zip-directory scan instead of opening the path twice. OpenMapForUpdate
+// returns the parsed sheets alongside the writer; the caller mutates the sheets in memory
+// and calls Commit to persist them, raw-copying the still-open non-content.json entries.
+// The caller MUST Close the writer (a deferred Close right after a successful open is the
+// expected pattern); Close is idempotent and is a no-op after a successful Commit.
+type MapWriter struct {
+	path      string
+	file      *os.File
+	zr        *zip.Reader
+	closed    bool
+	committed bool
+}
+
+// OpenMapForUpdate opens path once, parses content.json into sheets, and keeps the zip
+// open for a subsequent Commit. The returned MapWriter owns the open file handle and must
+// be closed by the caller. Errors mirror ReadMap's exactly, since handlers surface them as
+// user-visible tool errors.
+func OpenMapForUpdate(path string) (sheets []Sheet, mw *MapWriter, err error) {
+	zr, f, err := openZipReaderAtPath(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sheets, err = parseContentFromZip(zr)
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, err
+	}
+
+	return sheets, &MapWriter{path: path, file: f, zr: zr}, nil
+}
+
+// Commit serializes sheets back into the .xmind file, preserving every non-content.json
+// entry via raw copy from the open handle, then atomically swaps the result into place.
+// On success the read handle is closed before the swap, so the swap runs with no open
+// handle on the original; if Commit fails before that point the handle is left open for
+// the caller's Close to release. Commit is single-use: a second call, or a call after
+// Close, returns an error. Unlike Close, Commit is not nil-safe: OpenMapForUpdate always
+// returns a non-nil writer when its error is nil, so a correct caller never reaches here
+// with a nil receiver.
+func (mw *MapWriter) Commit(sheets []Sheet) error {
+	if mw.committed {
+		return fmt.Errorf("map already committed")
+	}
+	if mw.closed {
+		return fmt.Errorf("commit after close")
+	}
+
+	if err := writeMapBody(mw.path, sheets, mw.zr, func() error {
+		mw.closed = true
+		return mw.file.Close()
+	}); err != nil {
+		return err
+	}
+
+	mw.committed = true
+	return nil
+}
+
+// Close releases the open read handle. It is idempotent, nil-safe, and safe to call after
+// Commit (which already closes the handle). A nil receiver is a no-op so callers can defer
+// Close even on paths where the open returned a tool error and left the writer nil.
+func (mw *MapWriter) Close() error {
+	if mw == nil || mw.closed {
+		return nil
+	}
+	mw.closed = true
+	return mw.file.Close()
+}

--- a/internal/xmind/update_test.go
+++ b/internal/xmind/update_test.go
@@ -1,0 +1,299 @@
+package xmind
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// readContentJSON returns the raw content.json bytes from a .xmind zip.
+func readContentJSON(t *testing.T, path string) []byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	st, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	zr, err := zip.NewReader(f, st.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, zf := range zr.File {
+		if zf.Name != "content.json" {
+			continue
+		}
+		rc, err := zf.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+	t.Fatal("content.json not found")
+	return nil
+}
+
+func TestOpenMapForUpdatePreservesNonContentEntries(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+	before := zipEntryNames(t, dst)
+
+	sheets, mw, err := OpenMapForUpdate(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mw.Close() }()
+	if err := mw.Commit(sheets); err != nil {
+		t.Fatal(err)
+	}
+
+	if after := zipEntryNames(t, dst); !slices.Equal(before, after) {
+		t.Fatalf("zip entry names changed:\nbefore: %v\nafter:  %v", before, after)
+	}
+}
+
+func TestOpenMapForUpdateRawMessageFieldsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+
+	sheets, mw, err := OpenMapForUpdate(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mw.Close() }()
+	if len(sheets) == 0 {
+		t.Fatal("no sheets")
+	}
+	themeBefore := append([]byte(nil), sheets[0].Theme...)
+	if len(themeBefore) == 0 {
+		t.Fatal("expected sheet[0].Theme to be non-empty in kitchen sink")
+	}
+	if err := mw.Commit(sheets); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := ReadMap(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(themeBefore, s2[0].Theme) {
+		t.Fatalf("Theme RawMessage changed (len before %d after %d)", len(themeBefore), len(s2[0].Theme))
+	}
+}
+
+// TestCommitMatchesWriteMap proves the single-open Commit path produces a byte-identical
+// content.json and the same entry set as the read-fresh WriteMap path for the same mutation.
+func TestCommitMatchesWriteMap(t *testing.T) {
+	dir := t.TempDir()
+	viaWrite := filepath.Join(dir, "write.xmind")
+	viaCommit := filepath.Join(dir, "commit.xmind")
+	if err := copyFile(kitchenSinkPath(t), viaWrite); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(kitchenSinkPath(t), viaCommit); err != nil {
+		t.Fatal(err)
+	}
+
+	mutate := func(sheets []Sheet) {
+		sheets[0].RootTopic.Title = "Mutated Root"
+	}
+
+	// WriteMap path.
+	ws, err := ReadMap(viaWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutate(ws)
+	if err := WriteMap(viaWrite, ws); err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit path.
+	cs, mw, err := OpenMapForUpdate(viaCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mw.Close() }()
+	mutate(cs)
+	if err := mw.Commit(cs); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(readContentJSON(t, viaWrite), readContentJSON(t, viaCommit)) {
+		t.Fatal("content.json differs between WriteMap and Commit paths")
+	}
+	if !slices.Equal(zipEntryNames(t, viaWrite), zipEntryNames(t, viaCommit)) {
+		t.Fatal("zip entry sets differ between WriteMap and Commit paths")
+	}
+}
+
+func TestCommitAtomicSafetyOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+	sheets, mw, err := OpenMapForUpdate(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mw.Close() }()
+
+	before := fileSHA256(t, dst)
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Commit(sheets); err == nil {
+		t.Fatal("expected Commit to fail when temp dir is not writable")
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		if strings.HasPrefix(e.Name(), ".xmind-tmp-") {
+			t.Fatalf("leaked temp file: %s", e.Name())
+		}
+	}
+	if after := fileSHA256(t, dst); after != before {
+		t.Fatalf("original file changed after a failed commit: before %s, after %s", before, after)
+	}
+}
+
+func TestCommitPreservesOriginalOnSwapFailure(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+	sheets, mw, err := OpenMapForUpdate(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mw.Close() }()
+	before := fileSHA256(t, dst)
+
+	orig := osRename
+	t.Cleanup(func() { osRename = orig })
+	osRename = func(string, string) error {
+		return errors.New("injected swap failure")
+	}
+
+	if err := mw.Commit(sheets); err == nil {
+		t.Fatal("expected Commit to fail when the swap rename fails")
+	}
+
+	if after := fileSHA256(t, dst); after != before {
+		t.Fatalf("original file changed after a failed swap: before %s, after %s", before, after)
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		if strings.HasPrefix(e.Name(), ".xmind-tmp-") {
+			t.Fatalf("leaked temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestMapWriterLifecycleGuards(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+
+	sheets, mw, err := OpenMapForUpdate(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Commit(sheets); err != nil {
+		t.Fatal(err)
+	}
+	// A second Commit must be rejected.
+	if err := mw.Commit(sheets); err == nil {
+		t.Fatal("expected second Commit to fail")
+	}
+	// Close after a successful Commit is a no-op and must not error.
+	if err := mw.Close(); err != nil {
+		t.Fatalf("Close after Commit: %v", err)
+	}
+	// Close is idempotent.
+	if err := mw.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	// The committed content must still be readable.
+	if _, err := ReadMap(dst); err != nil {
+		t.Fatalf("read committed map: %v", err)
+	}
+}
+
+func TestMapWriterCommitAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "k.xmind")
+	if err := copyFile(kitchenSinkPath(t), dst); err != nil {
+		t.Fatal(err)
+	}
+	sheets, mw, err := OpenMapForUpdate(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Commit(sheets); err == nil {
+		t.Fatal("expected Commit after Close to fail")
+	}
+}
+
+func TestOpenMapForUpdateErrorParity(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope.xmind")
+		_, readErr := ReadMap(missing)
+		_, mw, openErr := OpenMapForUpdate(missing)
+		if mw != nil {
+			t.Fatal("expected nil MapWriter on error")
+		}
+		if readErr == nil || openErr == nil || readErr.Error() != openErr.Error() {
+			t.Fatalf("error mismatch: read=%v open=%v", readErr, openErr)
+		}
+	})
+
+	t.Run("not a zip", func(t *testing.T) {
+		bad := filepath.Join(t.TempDir(), "bad.xmind")
+		if err := os.WriteFile(bad, []byte("not a zip"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, readErr := ReadMap(bad)
+		_, _, openErr := OpenMapForUpdate(bad)
+		if readErr == nil || openErr == nil || readErr.Error() != openErr.Error() {
+			t.Fatalf("error mismatch: read=%v open=%v", readErr, openErr)
+		}
+	})
+}

--- a/internal/xmind/writer.go
+++ b/internal/xmind/writer.go
@@ -141,8 +141,26 @@ func WriteMap(path string, sheets []Sheet) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = oldFile.Close() }()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = oldFile.Close()
+		}
+	}()
 
+	return writeMapBody(path, sheets, oldZR, func() error {
+		closed = true
+		return oldFile.Close()
+	})
+}
+
+// writeMapBody serializes sheets into a new content.json and writes a fresh .xmind zip
+// at a temp path, raw-copying every non-content.json entry from zr, then atomically
+// swaps it into path. releaseSource is invoked once the entry copy is complete (and
+// before the atomic swap) so the caller can close the source handle that backs zr;
+// this lets the swap run with no open handle on the original. On any failure the temp
+// file is removed and the original is left untouched.
+func writeMapBody(path string, sheets []Sheet, zr *zip.Reader, releaseSource func() error) error {
 	data, err := marshalSheetsForContentJSON(sheets)
 	if err != nil {
 		return fmt.Errorf("marshal content.json: %w", err)
@@ -154,16 +172,16 @@ func WriteMap(path string, sheets []Sheet) error {
 		return fmt.Errorf("create temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	committed := false
+	swapped := false
 	defer func() {
-		if !committed {
+		if !swapped {
 			_ = os.Remove(tmpPath)
 		}
 	}()
 
 	zw := zip.NewWriter(tmp)
 
-	if err := copyZipEntriesExceptContentJSON(zw, oldZR); err != nil {
+	if err := copyZipEntriesExceptContentJSON(zw, zr); err != nil {
 		abortZipWriterAndFile(zw, tmp)
 		return err
 	}
@@ -173,10 +191,17 @@ func WriteMap(path string, sheets []Sheet) error {
 		return err
 	}
 
+	if releaseSource != nil {
+		if err := releaseSource(); err != nil {
+			abortZipWriterAndFile(zw, tmp)
+			return fmt.Errorf("close source handle: %w", err)
+		}
+	}
+
 	if err := finishZipTempFile(zw, tmp, tmpPath, path); err != nil {
 		return err
 	}
-	committed = true
+	swapped = true
 	return nil
 }
 


### PR DESCRIPTION
Mutating handlers previously opened each `.xmind` file twice per call: once to read content.json and again inside WriteMap to re-read and raw-copy the surviving zip entries. This adds a single-open read-then-commit handle so a mutation reuses one zip-directory scan.

Changes:
- Add `xmind.OpenMapForUpdate` returning parsed sheets plus a `*xmind.MapWriter` that keeps the zip reader open for `Commit`
- Extract `writeMapBody` from `WriteMap` with a `releaseSource` callback so the source handle closes before the atomic swap (no open handle on the original during the swap, as Windows requires); `WriteMap` and `MapWriter.Commit` now share it
- Extract `parseContentFromZip` from `ReadMap` and route both read paths through the shared `openZipReaderAtPath` helper
- Add `statAndOpenMapForUpdate` and the `loadSheet...ForUpdate` helpers; migrate the mutating handlers in `mutate.go`, `sheets.go`, and `utils.go` from `xmind.WriteMap` to `mw.Commit`
- Make `Commit` single-use and `Close` idempotent and nil-safe so a `defer mw.Close()` is correct on every return path
- Document the single-open mutation path in `AGENTS.md`
- Cover the new handle with `update_test.go` and `update_integration_test.go`

`WriteMap` (read-fresh) is retained for tests and `CreateNewMap`; the temp-then-swap atomicity mechanics are unchanged.

Closes #49