### PR TITLE
fix: close file handle before atomic replace on Windows + Go 1.24 compat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mab-go/xmind-mcp
 
-go 1.26.1
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/server/handler/mutate.go
+++ b/internal/server/handler/mutate.go
@@ -490,7 +490,8 @@ func (h *XMindHandler) AddTopic(ctx context.Context, req mcp.CallToolRequest) (*
 // for a caller-fixable dangling summary reference (the source map opened fine), a protocol error
 // otherwise (nil root / JSON round-trip failures are genuine internal faults).
 func duplicateCloneFailure(err error) (*mcp.CallToolResult, error) {
-	if dangErr, ok := errors.AsType[*cloneDanglingSummaryRefError](err); ok {
+	var dangErr *cloneDanglingSummaryRefError
+	if errors.As(err, &dangErr) {
 		return mcp.NewToolResultError(dangErr.Error()), nil
 	}
 	return nil, fmt.Errorf("duplicate topic: %w", err)

--- a/internal/xmind/writer.go
+++ b/internal/xmind/writer.go
@@ -141,16 +141,17 @@ func WriteMap(path string, sheets []Sheet) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = oldFile.Close() }()
 
 	data, err := marshalSheetsForContentJSON(sheets)
 	if err != nil {
+		_ = oldFile.Close()
 		return fmt.Errorf("marshal content.json: %w", err)
 	}
 
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".xmind-tmp-*")
 	if err != nil {
+		_ = oldFile.Close()
 		return fmt.Errorf("create temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
@@ -165,12 +166,24 @@ func WriteMap(path string, sheets []Sheet) error {
 
 	if err := copyZipEntriesExceptContentJSON(zw, oldZR); err != nil {
 		abortZipWriterAndFile(zw, tmp)
+		_ = oldFile.Close()
 		return err
 	}
 
 	if err := writeZipBytes(zw, "content.json", data); err != nil {
 		abortZipWriterAndFile(zw, tmp)
+		_ = oldFile.Close()
 		return err
+	}
+
+	// Close the original file BEFORE atomic replace.
+	// On Windows, os.Rename refuses to touch a file that still has an open
+	// handle (ERROR_SHARING_VIOLATION). The deferred-close approach works on
+	// Unix (inode-based rename), but on Windows it fires too late — after
+	// replaceTempFile has already attempted the rename.
+	if err := oldFile.Close(); err != nil {
+		abortZipWriterAndFile(zw, tmp)
+		return fmt.Errorf("close old file: %w", err)
 	}
 
 	if err := finishZipTempFile(zw, tmp, tmpPath, path); err != nil {


### PR DESCRIPTION
## 发生了什么？

在 Windows 上用这个 MCP 的时候，创建完思维导图之后，任何修改操作（加节点、改内容）都会直接报错失败。错误信息是 `The process cannot access the file because it is being used by another process`——就是说"你的文件正在被别人用着"。

查了一圈发现，是 `WriteMap` 函数里打开原始文件之后，用 `defer` 推迟关闭。这招在 Mac/Linux 上没问题，但 Windows 特别严格——只要你手还抓着这个文件，就不让你碰。结果就是替换文件的操作被 Windows 拦下来了。

## What happened?

On Windows, after creating a mind map, every write operation (adding topics, editing) would fail with "file being used by another process". Turns out `WriteMap` opens the original file, then defers the close. On Unix systems this is fine, but Windows locks the file and won't let anything touch it while the handle is open. The atomic replace step hits a wall.

## 修了什么？

就改了 3 个文件，17 行代码：

- **writer.go**：不再靠 `defer` 关了——确保所有数据读完之后、替换文件之前，先把旧文件的把手松开。
- **mutate.go**：一行代码从 Go 新版写法改成通用写法，方便更多人编译。
- **go.mod**：Go 版本要求从 1.26.1 降到 1.24，降低门槛。

## What's changed?

3 files, 17 lines:

- **writer.go**: Close the file handle *before* the atomic replace step. Don't wait for defer to kick in—by then it's too late on Windows.
- **mutate.go**: Use standard `errors.As` instead of newer `errors.AsType`, making it buildable on Go 1.24.
- **go.mod**: Lower Go version requirement from 1.26.1 to 1.24.

## 修完之后怎么样？

Windows 11 上测试通过：创建导图、加节点、批量加 42 个节点、导入大纲——全都正常运行了。

## Does it work?

Tested on Windows 11 + Go 1.24.2: create, add topic, bulk add 42 nodes, import outline—all green ✓
